### PR TITLE
fix: add pytest path configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest can import the `bot` package by appending project root to `sys.path`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a64ffdd88c83299a1c8475c47cbad8