### PR TITLE
Ensure models imported before DB initialization

### DIFF
--- a/bot/database.py
+++ b/bot/database.py
@@ -14,4 +14,5 @@ Base = declarative_base()
 
 def init_db():
     # Импортируем модели, чтобы они были зарегистрированы в Base.metadata
+    from bot import models  # noqa: F401
     Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- import `bot.models` in `init_db` so SQLAlchemy registers tables before creating the database

## Testing
- `PYTHONPATH=. pytest`
- `flake8 bot` *(fails: E302/E501 and other pre-existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a654259e6c8329b80b8f145c1d3635