### PR TITLE
Centralize logging setup for bot modules

### DIFF
--- a/bot/commands/add_chat.py
+++ b/bot/commands/add_chat.py
@@ -3,8 +3,9 @@ from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import ADD_CHAT_ENABLE
 from bot.utils.chat_manager import add_chat
+from bot.config.logging import setup_logging
 
-logging.basicConfig(level=logging.DEBUG)
+setup_logging()
 
 
 async def can_add_chat(message: Message) -> bool:

--- a/bot/commands/best_qa_stat.py
+++ b/bot/commands/best_qa_stat.py
@@ -5,8 +5,9 @@ from bot.config.flags import BEST_QA_STAT_ENABLE
 from bot.database import SessionLocal
 from bot.models import WinnerStats
 from bot.utils.game_engine import format_declension
+from bot.config.logging import setup_logging
 
-logging.basicConfig(level=logging.DEBUG)
+setup_logging()
 
 
 def get_stats(chat_id: str) -> list:

--- a/bot/commands/remove_chat.py
+++ b/bot/commands/remove_chat.py
@@ -3,8 +3,9 @@ from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import REMOVE_CHAT_ENABLE
 from bot.utils.chat_manager import remove_chat
+from bot.config.logging import setup_logging
 
-logging.basicConfig(level=logging.DEBUG)
+setup_logging()
 
 
 async def handle_remove_chat(message: Message) -> None:

--- a/bot/commands/search.py
+++ b/bot/commands/search.py
@@ -10,12 +10,9 @@ from aiogram.fsm.state import StatesGroup, State
 
 from bot.config.tokens import OPENAI_API_KEY
 from bot.config.gpt_prompt import PROMPT
+from bot.config.logging import setup_logging
 
-# Настройка логирования
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s"
-)
+setup_logging()
 
 openai.api_key = OPENAI_API_KEY
 router = Router()

--- a/bot/config/logging.py
+++ b/bot/config/logging.py
@@ -1,0 +1,13 @@
+import logging
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure basic logging for the project.
+
+    Parameters
+    ----------
+    level: int, optional
+        Logging level passed to ``logging.basicConfig``. By default
+        :data:`logging.INFO` is used.
+    """
+    logging.basicConfig(level=level,
+                        format="%(asctime)s - %(levelname)s - %(message)s")

--- a/bot/messages/message_parse.py
+++ b/bot/messages/message_parse.py
@@ -2,6 +2,7 @@ import re
 import logging
 from bot.dicts.links_dict import LINKS
 from bot.messages.errors_parse import build_error_defs
+from bot.config.logging import setup_logging
 
 from typing import List, Tuple
 
@@ -33,7 +34,7 @@ def should_skip(keyword: str) -> bool:
     return False
 
 # Настройка логирования
-logging.basicConfig(level=logging.DEBUG)
+setup_logging()
 
 
 def find_links_by_keyword(keyword: str, enabled: bool):

--- a/bot/utils/run_bot.py
+++ b/bot/utils/run_bot.py
@@ -5,13 +5,14 @@ from bot.config.tokens import API_TOKEN
 from bot.database import init_db
 from bot.utils.handlers import register_handlers
 from bot.modules.commands_list import set_bot_commands
+from bot.config.logging import setup_logging
 
 
 async def run_bot():
     """
     Главная функция для запуска бота.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    setup_logging()
 
     # Инициализация базы данных
     init_db()


### PR DESCRIPTION
## Summary
- add `bot.config.logging.setup_logging` to unify logging configuration
- replace `logging.basicConfig` calls across bot modules with `setup_logging`

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a654290d908329b7ea2806afaffd45