### PR TITLE
feat: move reactions and links to sqlite cache

### DIFF
--- a/bot/messages/messages.py
+++ b/bot/messages/messages.py
@@ -1,6 +1,4 @@
-import asyncio
 import logging
-from datetime import datetime, timedelta
 import random
 
 from aiogram.types import Message
@@ -15,13 +13,10 @@ from bot.messages.maslina import handle_maslina
 from bot.messages.help_epa_message import get_auth_issue_response
 from bot.utils.participants import update_participant
 from bot.config.tokens import BOT_USERNAME
+from bot.storage.cache import cache
 
 
-# Хранилище для предотвращения повторных ответов (по чатам)
-recent_links: dict = {}  # Формат: {chat_id: {"url": время последнего ответа}}
-
-# Хранилище для подсчета лайков и дизлайков: {(chat_id, message_id): {"likes": int, "dislikes": int}}
-reaction_counts: dict = {}
+REACTION_TTL_SECONDS = 24 * 60 * 60
 
 
 def should_process_text(text: str) -> bool:
@@ -137,26 +132,17 @@ async def process_results(message: Message, results: list) -> None:
     if filtered_results:
         response: str = format_response(filtered_results)
         logging.debug(f"Отправка ссылки: {response}")
-        # Кнопка лайк с начальным значением 0
         like_button = InlineKeyboardButton(text="👍 0", callback_data="like_init")
-        # Кнопка дизлайк
         dislike_button = InlineKeyboardButton(text="👎 0", callback_data="dislike_init")
         keyboard = InlineKeyboardMarkup(inline_keyboard=[[like_button, dislike_button]], row_width=2)
         sent = await message.answer(response, reply_to_message_id=message.message_id, reply_markup=keyboard)
-        # Инициализируем счётчики для отправленного сообщения
-        reaction_counts[(sent.chat.id, sent.message_id)] = {"likes": 0, "dislikes": 0}
-        # Обновляем callback_data, чтобы содержали реальные chat_id и message_id
+        cache.init_reaction(sent.chat.id, sent.message_id, REACTION_TTL_SECONDS)
         new_like_data = f"like:{sent.chat.id}:{sent.message_id}"
         new_dislike_data = f"dislike:{sent.chat.id}:{sent.message_id}"
         like_button = InlineKeyboardButton(text="👍 0", callback_data=new_like_data)
         dislike_button = InlineKeyboardButton(text="👎 0", callback_data=new_dislike_data)
         keyboard = InlineKeyboardMarkup(inline_keyboard=[[like_button, dislike_button]], row_width=2)
         await sent.edit_reply_markup(reply_markup=keyboard)
-
-        # Планируем удаление ссылок из recent_links через таймаут
-        if flag.TIMEOUT_RESPONSES_ENABLE:
-            for _, url in filtered_results:
-                asyncio.create_task(remove_link_after_timeout(message.chat.id, url))
     else:
         logging.debug("Все ссылки уже были отправлены недавно.")
 
@@ -166,16 +152,14 @@ def filter_recent_links(chat_id: int, results: list) -> list:
     Фильтрует ссылки, которые уже были отправлены недавно для конкретного чата.
     """
     filtered_results = []
-    chat_recent_links = recent_links.setdefault(chat_id, {})
     for name, url in results:
-        if (url in chat_recent_links
-                and datetime.now() - chat_recent_links[url]
-                < timedelta(minutes=flag.TIMEOUT_MINUTES)):
-            logging.debug(f"Пропуск отправки ссылки '{url}' "
-                          f"для чата {chat_id} (отправлялась недавно).")
+        if cache.is_recent_link(chat_id, url):
+            logging.debug(
+                f"Пропуск отправки ссылки '{url}' для чата {chat_id} (отправлялась недавно)."
+            )
         else:
             filtered_results.append((name, url))
-            chat_recent_links[url] = datetime.now()
+            cache.set_recent_link(chat_id, url, flag.TIMEOUT_MINUTES * 60)
     return filtered_results
 
 
@@ -185,19 +169,6 @@ def format_response(results: list) -> str:
     """
     return ("Возможно это поможет разобраться:\n"
             + "\n".join([f"{name}: {url}" for name, url in results]))
-
-
-async def remove_link_after_timeout(chat_id: int, url: str) -> None:
-    """
-    Удаляет ссылку из recent_links для конкретного чата через заданный таймаут.
-    """
-    await asyncio.sleep(flag.TIMEOUT_MINUTES * 60)
-    chat_recent_links = recent_links.get(chat_id, {})
-    if url in chat_recent_links:
-        del chat_recent_links[url]
-        logging.debug(f"Ссылка '{url}' удалена из кэша для чата {chat_id}.")
-
-
 async def handle_like_callback(callback_query: CallbackQuery) -> None:
     """
     Обработка нажатия на кнопку лайк.
@@ -206,17 +177,11 @@ async def handle_like_callback(callback_query: CallbackQuery) -> None:
     _, chat_id_str, message_id_str = data.split(":")
     chat_id = int(chat_id_str)
     message_id = int(message_id_str)
-    key = (chat_id, message_id)
-    if key not in reaction_counts:
+    if not cache.get_reaction(chat_id, message_id):
         await callback_query.answer()
         return
-    # Увеличиваем счётчик лайков
-    reaction_counts[key]["likes"] += 1
-    likes = reaction_counts[key]["likes"]
-    dislikes = reaction_counts[key]["dislikes"]
-    # Получаем текущий объект сообщения
+    likes, dislikes = cache.increment_reaction(chat_id, message_id, "like", REACTION_TTL_SECONDS)
     msg = callback_query.message
-    # Обновляем клавиатуру с новым значением лайков и дизлайков
     like_button = InlineKeyboardButton(text=f"👍 {likes}", callback_data=f"like:{chat_id}:{message_id}")
     dislike_button = InlineKeyboardButton(text=f"👎 {dislikes}", callback_data=f"dislike:{chat_id}:{message_id}")
     keyboard = InlineKeyboardMarkup(inline_keyboard=[[like_button, dislike_button]], row_width=2)
@@ -232,24 +197,16 @@ async def handle_dislike_callback(callback_query: CallbackQuery) -> None:
     _, chat_id_str, message_id_str = data.split(":")
     chat_id = int(chat_id_str)
     message_id = int(message_id_str)
-    key = (chat_id, message_id)
-    if key not in reaction_counts:
+    if not cache.get_reaction(chat_id, message_id):
         await callback_query.answer()
         return
-    # Увеличиваем счётчик дизлайков
-    reaction_counts[key]["dislikes"] += 1
-    dislikes = reaction_counts[key]["dislikes"]
-    likes = reaction_counts[key]["likes"]
+    likes, dislikes = cache.increment_reaction(chat_id, message_id, "dislike", REACTION_TTL_SECONDS)
     msg = callback_query.message
-    # Если дизлайков стало больше, чем лайков — удаляем сообщение
     if dislikes > likes:
         await msg.delete()
-        # Удаляем записи из хранилищ
-        reaction_counts.pop(key, None)
-        recent_links.get(chat_id, {}).pop(msg.text, None)
+        cache.remove_reaction(chat_id, message_id)
         await callback_query.answer("Сообщение удалено")
     else:
-        # Обновляем клавиатуру с новыми значениями лайков и дизлайков
         like_button = InlineKeyboardButton(text=f"👍 {likes}", callback_data=f"like:{chat_id}:{message_id}")
         dislike_button = InlineKeyboardButton(text=f"👎 {dislikes}", callback_data=f"dislike:{chat_id}:{message_id}")
         keyboard = InlineKeyboardMarkup(inline_keyboard=[[like_button, dislike_button]], row_width=2)

--- a/bot/storage/__init__.py
+++ b/bot/storage/__init__.py
@@ -1,0 +1,1 @@
+# Storage package for caching with TTL

--- a/bot/storage/cache.py
+++ b/bot/storage/cache.py
@@ -1,0 +1,130 @@
+import os
+import sqlite3
+import threading
+from datetime import datetime
+
+
+class SQLiteCache:
+    """Simple SQLite-backed cache with TTL support."""
+
+    def __init__(self, path: str = "data/cache.db"):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        self.conn = sqlite3.connect(path, check_same_thread=False)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS recent_links (
+                chat_id INTEGER NOT NULL,
+                url TEXT NOT NULL,
+                expires_at REAL NOT NULL,
+                PRIMARY KEY (chat_id, url)
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reaction_counts (
+                chat_id INTEGER NOT NULL,
+                message_id INTEGER NOT NULL,
+                likes INTEGER NOT NULL DEFAULT 0,
+                dislikes INTEGER NOT NULL DEFAULT 0,
+                expires_at REAL NOT NULL,
+                PRIMARY KEY (chat_id, message_id)
+            )
+            """
+        )
+        self.conn.commit()
+        self.lock = threading.Lock()
+
+    # --- Recent links operations ---
+    def set_recent_link(self, chat_id: int, url: str, ttl_seconds: int) -> None:
+        with self.lock:
+            expires_at = datetime.now().timestamp() + ttl_seconds
+            self.conn.execute(
+                "REPLACE INTO recent_links(chat_id, url, expires_at) VALUES(?,?,?)",
+                (chat_id, url, expires_at),
+            )
+            self.conn.commit()
+
+    def is_recent_link(self, chat_id: int, url: str) -> bool:
+        with self.lock:
+            now = datetime.now().timestamp()
+            cur = self.conn.execute(
+                "SELECT expires_at FROM recent_links WHERE chat_id=? AND url=?",
+                (chat_id, url),
+            )
+            row = cur.fetchone()
+            if not row:
+                return False
+            if row[0] < now:
+                self.conn.execute(
+                    "DELETE FROM recent_links WHERE chat_id=? AND url=?",
+                    (chat_id, url),
+                )
+                self.conn.commit()
+                return False
+            return True
+
+    # --- Reaction counts operations ---
+    def init_reaction(self, chat_id: int, message_id: int, ttl_seconds: int) -> None:
+        with self.lock:
+            expires_at = datetime.now().timestamp() + ttl_seconds
+            self.conn.execute(
+                "REPLACE INTO reaction_counts(chat_id, message_id, likes, dislikes, expires_at) VALUES(?,?,?,?,?)",
+                (chat_id, message_id, 0, 0, expires_at),
+            )
+            self.conn.commit()
+
+    def increment_reaction(self, chat_id: int, message_id: int, reaction: str, ttl_seconds: int):
+        with self.lock:
+            now = datetime.now().timestamp()
+            expires_at = now + ttl_seconds
+            cur = self.conn.execute(
+                "SELECT likes, dislikes, expires_at FROM reaction_counts WHERE chat_id=? AND message_id=?",
+                (chat_id, message_id),
+            )
+            row = cur.fetchone()
+            if not row or row[2] < now:
+                likes = dislikes = 0
+            else:
+                likes, dislikes, _ = row
+            if reaction == "like":
+                likes += 1
+            else:
+                dislikes += 1
+            self.conn.execute(
+                "REPLACE INTO reaction_counts(chat_id, message_id, likes, dislikes, expires_at) VALUES(?,?,?,?,?)",
+                (chat_id, message_id, likes, dislikes, expires_at),
+            )
+            self.conn.commit()
+            return likes, dislikes
+
+    def get_reaction(self, chat_id: int, message_id: int):
+        with self.lock:
+            now = datetime.now().timestamp()
+            cur = self.conn.execute(
+                "SELECT likes, dislikes, expires_at FROM reaction_counts WHERE chat_id=? AND message_id=?",
+                (chat_id, message_id),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            likes, dislikes, expires_at = row
+            if expires_at < now:
+                self.conn.execute(
+                    "DELETE FROM reaction_counts WHERE chat_id=? AND message_id=?",
+                    (chat_id, message_id),
+                )
+                self.conn.commit()
+                return None
+            return {"likes": likes, "dislikes": dislikes}
+
+    def remove_reaction(self, chat_id: int, message_id: int) -> None:
+        with self.lock:
+            self.conn.execute(
+                "DELETE FROM reaction_counts WHERE chat_id=? AND message_id=?",
+                (chat_id, message_id),
+            )
+            self.conn.commit()
+
+
+cache = SQLiteCache()


### PR DESCRIPTION
## Summary
- persist recent links and reaction counters in a SQLite cache with TTL
- update link filtering and reaction handlers to use the cache

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bot')*

------
https://chatgpt.com/codex/tasks/task_e_68a6544100488329a4c4c19df7a8efc1