### PR TITLE
Validate required tokens

### DIFF
--- a/bot/config/tokens.py
+++ b/bot/config/tokens.py
@@ -6,10 +6,17 @@ load_dotenv()
 
 # Telegram Bot tokens
 BOT_USERNAME = os.getenv("BOT_USERNAME")
+if BOT_USERNAME is None:
+    raise RuntimeError("BOT_USERNAME is not set")
+
 API_TOKEN = os.getenv("API_TOKEN")
+if API_TOKEN is None:
+    raise RuntimeError("API_TOKEN is not set")
 
 # OpenAI token
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if OPENAI_API_KEY is None:
+    raise RuntimeError("OPENAI_API_KEY is not set")
 
 # пользователь который выдает доступ к админ правам
 ADMIN_USER_ID = os.getenv("ADMIN_USER_ID")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+os.environ.setdefault("BOT_USERNAME", "dummy_username")
+os.environ.setdefault("API_TOKEN", "dummy_token")
+os.environ.setdefault("OPENAI_API_KEY", "dummy_openai")

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,17 @@
+import importlib
+import pytest
+
+
+@pytest.mark.parametrize(
+    "missing", ["BOT_USERNAME", "API_TOKEN", "OPENAI_API_KEY"]
+)
+def test_missing_env_var_raises(monkeypatch, missing):
+    import bot.config.tokens as tokens
+
+    monkeypatch.delenv(missing, raising=False)
+    with pytest.raises(RuntimeError) as excinfo:
+        importlib.reload(tokens)
+    assert missing in str(excinfo.value)
+
+    monkeypatch.setenv(missing, "restored")
+    importlib.reload(tokens)


### PR DESCRIPTION
## Summary
- raise explicit error when BOT_USERNAME, API_TOKEN or OPENAI_API_KEY are missing
- add tests ensuring missing token raises RuntimeError
- provide default env variables for tests

## Testing
- `flake8 bot/config/tokens.py tests/test_tokens.py tests/conftest.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6544469fc8329a4e5c34ac636679c