### PR TITLE
chore: sort imports to satisfy lint

### DIFF
--- a/bot/commands/add_chat.py
+++ b/bot/commands/add_chat.py
@@ -1,4 +1,5 @@
 import logging
+
 from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import ADD_CHAT_ENABLE

--- a/bot/commands/announce.py
+++ b/bot/commands/announce.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Optional, Tuple, Dict, Any
+from typing import Any, Dict, Optional, Tuple
 
 from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import StatesGroup, State
-
+from aiogram.fsm.state import State, StatesGroup
 from bot.config.flags import ANNOUNCE_ENABLE
 from bot.database import SessionLocal
 from bot.models import Chat

--- a/bot/commands/best_qa.py
+++ b/bot/commands/best_qa.py
@@ -2,12 +2,12 @@ from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import BEST_QA_ENABLE
 from bot.utils.game_engine import (
-    update_last_winner,
-    update_winner_stats,
+    format_winner_mention,
+    get_last_winner,
     get_random_participant,
     is_new_day,
-    format_winner_mention,
-    get_last_winner
+    update_last_winner,
+    update_winner_stats,
 )
 
 

--- a/bot/commands/best_qa_stat.py
+++ b/bot/commands/best_qa_stat.py
@@ -1,4 +1,5 @@
 import logging
+
 from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import BEST_QA_STAT_ENABLE

--- a/bot/commands/chat_list.py
+++ b/bot/commands/chat_list.py
@@ -1,9 +1,10 @@
 import logging
+
 from aiogram import Router, types
 from aiogram.filters import Command
-from bot.utils.chat_manager import get_all_chats
 from bot.database import SessionLocal
 from bot.models import AdminUser
+from bot.utils.chat_manager import get_all_chats
 
 logger = logging.getLogger(__name__)
 router = Router()

--- a/bot/commands/docs.py
+++ b/bot/commands/docs.py
@@ -1,9 +1,10 @@
-from aiogram.filters import Command
-from aiogram.types import Message
-from bot.modules.menu import create_menu
-from bot.config.flags import DOCS_ENABLE
 import logging
+
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+from bot.config.flags import DOCS_ENABLE
+from bot.modules.menu import create_menu
 
 logger = logging.getLogger(__name__)
 

--- a/bot/commands/get_access.py
+++ b/bot/commands/get_access.py
@@ -4,11 +4,10 @@ from typing import Tuple
 
 from aiogram import Router, types
 from aiogram.filters import Command
-from bot.database import SessionLocal
-from bot.models import AdminUser
 from bot.config.flags import GET_ACCESS_ENABLE
 from bot.config.tokens import ADMIN_USER_ID
-
+from bot.database import SessionLocal
+from bot.models import AdminUser
 
 logger = logging.getLogger(__name__)
 router = Router()

--- a/bot/commands/help.py
+++ b/bot/commands/help.py
@@ -1,9 +1,10 @@
 import logging
+
 from aiogram.filters import Command
 from aiogram.types import Message
-from bot.modules.commands_list import get_all_commands
 from bot.database import SessionLocal
 from bot.models import AdminUser
+from bot.modules.commands_list import get_all_commands
 
 logger = logging.getLogger(__name__)
 

--- a/bot/commands/remove_chat.py
+++ b/bot/commands/remove_chat.py
@@ -1,4 +1,5 @@
 import logging
+
 from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import REMOVE_CHAT_ENABLE

--- a/bot/commands/search.py
+++ b/bot/commands/search.py
@@ -1,15 +1,14 @@
 import asyncio
 import logging
-import openai
 from typing import Optional
 
+import openai
 from aiogram import Router, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import StatesGroup, State
-
-from bot.config.tokens import OPENAI_API_KEY
+from aiogram.fsm.state import State, StatesGroup
 from bot.config.gpt_prompt import PROMPT
+from bot.config.tokens import OPENAI_API_KEY
 
 # Настройка логирования
 logging.basicConfig(

--- a/bot/config/tokens.py
+++ b/bot/config/tokens.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 # Загружаем переменные окружения из файла .env

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
-
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 # Здесь мы используем SQLite и сохраняем базу в файле data/bot.db
 DATABASE_URL = "sqlite:///data/bot.db"

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from bot.utils.run_bot import run_bot
 
 

--- a/bot/messages/bot_tag.py
+++ b/bot/messages/bot_tag.py
@@ -1,5 +1,6 @@
-from aiogram import types
 from pathlib import Path
+
+from aiogram import types
 from aiogram.types import FSInputFile
 
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/bot/messages/errors_parse.py
+++ b/bot/messages/errors_parse.py
@@ -1,5 +1,7 @@
 import re
+
 from bot.dicts.errors_dict import raw_errors
+
 
 def _build_code_pattern(code: str) -> str:
     """

--- a/bot/messages/maslina.py
+++ b/bot/messages/maslina.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
-from aiogram.types import Message, FSInputFile
+
+from aiogram.types import FSInputFile, Message
 
 
 def contains_maslina(text: str) -> bool:

--- a/bot/messages/message_parse.py
+++ b/bot/messages/message_parse.py
@@ -1,9 +1,10 @@
-import re
 import logging
+import re
+from typing import List, Tuple
+
 from bot.dicts.links_dict import LINKS
 from bot.messages.errors_parse import build_error_defs
 
-from typing import List, Tuple
 
 def parse_error_codes(text: str, enabled: bool):
     """

--- a/bot/messages/messages.py
+++ b/bot/messages/messages.py
@@ -1,21 +1,23 @@
 import asyncio
 import logging
-from datetime import datetime, timedelta
 import random
-
-from aiogram.types import Message
-from aiogram.fsm.context import FSMContext
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, CallbackQuery
+from datetime import datetime, timedelta
 
 import bot.config.flags as flag
+from aiogram.fsm.context import FSMContext
+from aiogram.types import (
+    CallbackQuery,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+)
+from bot.config.tokens import BOT_USERNAME
+from bot.messages.bot_tag import handle_bot_tag
+from bot.messages.help_epa_message import get_auth_issue_response
+from bot.messages.maslina import handle_maslina
 from bot.messages.message_parse import find_links_by_keyword, parse_error_codes
 from bot.messages.who_request import handle_who_request
-from bot.messages.bot_tag import handle_bot_tag
-from bot.messages.maslina import handle_maslina
-from bot.messages.help_epa_message import get_auth_issue_response
 from bot.utils.participants import update_participant
-from bot.config.tokens import BOT_USERNAME
-
 
 # Хранилище для предотвращения повторных ответов (по чатам)
 recent_links: dict = {}  # Формат: {chat_id: {"url": время последнего ответа}}

--- a/bot/messages/who_request.py
+++ b/bot/messages/who_request.py
@@ -1,7 +1,8 @@
 import logging
 import re
-from aiogram.types import Message, FSInputFile
 from pathlib import Path
+
+from aiogram.types import FSInputFile, Message
 from bot.dicts import who_request_dict
 
 # Путь к папке с изображениями

--- a/bot/models.py
+++ b/bot/models.py
@@ -1,5 +1,5 @@
-from sqlalchemy import Column, Integer, String, DateTime, Boolean, func
 from bot.database import Base
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, func
 
 
 class LastWinner(Base):

--- a/bot/modules/buttons.py
+++ b/bot/modules/buttons.py
@@ -1,8 +1,9 @@
-from typing import Tuple, Optional
-from aiogram.types import CallbackQuery
-from aiogram.fsm.context import FSMContext
-from bot.modules.menu import create_menu
 import logging
+from typing import Optional, Tuple
+
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery
+from bot.modules.menu import create_menu
 
 logger = logging.getLogger(__name__)
 

--- a/bot/modules/commands_list.py
+++ b/bot/modules/commands_list.py
@@ -1,8 +1,8 @@
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
 from aiogram import Bot
 from aiogram.types import BotCommand
 from bot.config import flags
-
 
 # Декларативное описание команд
 COMMAND_DEFINITIONS: List[Dict[str, Any]] = [
@@ -170,8 +170,10 @@ def get_commands_for_scope(commands: List[Dict[str, Any]],
 
 async def set_bot_commands(bot: Bot, user_is_admin: bool = False) -> None:
     commands = get_all_commands(user_is_admin=user_is_admin)
-    from aiogram.types import (BotCommandScopeDefault,
-                               BotCommandScopeAllGroupChats)
+    from aiogram.types import (
+        BotCommandScopeAllGroupChats,
+        BotCommandScopeDefault,
+    )
     private_commands = get_commands_for_scope(commands,
                                               "private_chat")
     await bot.set_my_commands(private_commands,

--- a/bot/modules/menu.py
+++ b/bot/modules/menu.py
@@ -1,6 +1,7 @@
+import logging
+
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 from bot.dicts.links_dict import LINKS
-import logging
 
 
 def create_main_menu(user_id: int):

--- a/bot/utils/game_engine.py
+++ b/bot/utils/game_engine.py
@@ -1,10 +1,10 @@
-import random
 import logging
+import random
 from datetime import datetime, timezone
-from aiogram.utils.markdown import hlink
 
+from aiogram.utils.markdown import hlink
 from bot.database import SessionLocal
-from bot.models import LastWinner, WinnerStats, Participant
+from bot.models import LastWinner, Participant, WinnerStats
 
 logger = logging.getLogger(__name__)
 

--- a/bot/utils/handlers.py
+++ b/bot/utils/handlers.py
@@ -1,19 +1,19 @@
-from bot.commands.start import register_start_handler
-from bot.commands.help import register_help_handler
-from bot.commands.docs import register_docs_handler
-from bot.commands.announce import register_announce_handler
 from bot.commands.add_chat import register_add_chat_handler
-from bot.commands.remove_chat import register_remove_chat_handler
-from bot.commands.get_access import register_get_access_handler
-from bot.commands.search import register_search_handler
+from bot.commands.announce import register_announce_handler
 from bot.commands.best_qa import register_best_qa_handler
 from bot.commands.best_qa_stat import register_best_qa_stat_handler
 from bot.commands.chat_list import register_chat_list_handler
-from bot.commands.epa_guide import register_epa_guide_handler
+from bot.commands.docs import register_docs_handler
 from bot.commands.epa_contacts import register_epa_contacts_handler
+from bot.commands.epa_guide import register_epa_guide_handler
+from bot.commands.get_access import register_get_access_handler
+from bot.commands.help import register_help_handler
+from bot.commands.remove_chat import register_remove_chat_handler
+from bot.commands.search import register_search_handler
+from bot.commands.start import register_start_handler
 from bot.commands.vtb_support import register_vtb_support_handler
-from bot.modules.buttons import register_button_handlers
 from bot.messages.messages import register_message_handlers
+from bot.modules.buttons import register_button_handlers
 
 
 def register_handlers(dp):

--- a/bot/utils/participants.py
+++ b/bot/utils/participants.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+
 from bot.database import SessionLocal
 from bot.models import Participant
 

--- a/bot/utils/run_bot.py
+++ b/bot/utils/run_bot.py
@@ -1,10 +1,11 @@
-import logging
 import asyncio
+import logging
+
 from aiogram import Bot, Dispatcher
 from bot.config.tokens import API_TOKEN
 from bot.database import init_db
-from bot.utils.handlers import register_handlers
 from bot.modules.commands_list import set_bot_commands
+from bot.utils.handlers import register_handlers
 
 
 async def run_bot():


### PR DESCRIPTION
## Summary
- sort imports with isort to resolve linter errors

## Testing
- `flake8 bot`
- `isort --check-only bot`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a658da73348329868c124d5c4a279a