### PR TITLE
Add sync chat manager wrappers and fix tests

### DIFF
--- a/bot/commands/add_chat.py
+++ b/bot/commands/add_chat.py
@@ -2,7 +2,7 @@ import logging
 from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import ADD_CHAT_ENABLE
-from bot.utils.chat_manager import add_chat
+from bot.utils.chat_manager import add_chat_async
 from bot.config.logging import setup_logging
 
 setup_logging()
@@ -29,7 +29,7 @@ async def handle_add_chat(message: Message) -> None:
     added_by = message.from_user.username or message.from_user.full_name
 
     try:
-        await add_chat(chat_id, chat_title, added_by)
+        await add_chat_async(chat_id, chat_title, added_by)
     except Exception as e:
         logging.error(f"Ошибка при добавлении чата: {e}")
 

--- a/bot/commands/chat_list.py
+++ b/bot/commands/chat_list.py
@@ -3,7 +3,7 @@ from aiogram import Router, types
 from aiogram.filters import Command
 from sqlalchemy import select
 
-from bot.utils.chat_manager import get_all_chats
+from bot.utils.chat_manager import get_all_chats_async
 from bot.database import SessionLocal
 from bot.models import AdminUser
 
@@ -33,7 +33,7 @@ async def handle_chat_list(message: types.Message) -> None:
         return
 
     # Получаем список чатов
-    chats = await get_all_chats()
+    chats = await get_all_chats_async()
     if not chats:
         await message.answer("Список чатов пуст.")
         return

--- a/bot/commands/remove_chat.py
+++ b/bot/commands/remove_chat.py
@@ -2,7 +2,7 @@ import logging
 from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import REMOVE_CHAT_ENABLE
-from bot.utils.chat_manager import remove_chat
+from bot.utils.chat_manager import remove_chat_async
 from bot.config.logging import setup_logging
 
 setup_logging()
@@ -27,7 +27,7 @@ async def handle_remove_chat(message: Message) -> None:
     chat_id = message.chat.id
     removed_by = message.from_user.username or message.from_user.full_name
 
-    if await remove_chat(chat_id, removed_by):
+    if await remove_chat_async(chat_id, removed_by):
         logging.info(f"Чат {chat_id} успешно помечен как удалённый.")
     else:
         logging.debug(f"Чат {chat_id} не найден или уже удалён.")

--- a/bot/utils/chat_manager.py
+++ b/bot/utils/chat_manager.py
@@ -1,8 +1,10 @@
+import asyncio
 import logging
 from datetime import datetime
 
 from aiogram.types import Message
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.database import SessionLocal
 from bot.models import Chat
@@ -10,7 +12,12 @@ from bot.models import Chat
 logger = logging.getLogger(__name__)
 
 
-async def add_chat(chat_id: int, chat_title: str, added_by: str) -> None:
+# ---------------------------------------------------------------------------
+# Asynchronous implementations
+# ---------------------------------------------------------------------------
+
+
+async def add_chat_async(chat_id: int, chat_title: str, added_by: str) -> None:
     """
     Добавляет чат в базу данных или восстанавливает его,
     если он ранее был помечен как удалённый.
@@ -19,45 +26,81 @@ async def add_chat(chat_id: int, chat_title: str, added_by: str) -> None:
     :param chat_title: Название чата.
     :param added_by: Имя или username пользователя, добавившего чат.
     """
-    async with SessionLocal() as session:
-        try:
-            # Приводим chat_id к строке для единообразия хранения
-            result = await session.execute(
-                select(Chat).filter(Chat.chat_id == str(chat_id))
-            )
-            existing_chat = result.scalars().first()
-            if existing_chat:
-                if existing_chat.deleted:
-                    existing_chat.deleted = False
-                    existing_chat.deleted_by = None
-                    existing_chat.deleted_at = None
-                    await session.commit()
-                    logger.info(f"Чат {chat_id} восстановлен.")
-                else:
-                    logger.debug(
-                        f"Чат {chat_id} уже существует в базе данных."
-                    )
-                return
+    session = SessionLocal()
+    try:
+        if isinstance(session, AsyncSession):
+            async with session:
+                result = await session.execute(
+                    select(Chat).filter(Chat.chat_id == str(chat_id))
+                )
+                existing_chat = result.scalars().first()
+                if existing_chat:
+                    if existing_chat.deleted:
+                        existing_chat.deleted = False
+                        existing_chat.deleted_by = None
+                        existing_chat.deleted_at = None
+                        await session.commit()
+                        logger.info(f"Чат {chat_id} восстановлен.")
+                    else:
+                        logger.debug(
+                            f"Чат {chat_id} уже существует в базе данных."
+                        )
+                    return
 
-            new_chat = Chat(
-                chat_id=str(chat_id),
-                title=chat_title,
-                added_by=added_by,
-                added_at=datetime.now(),
-                deleted=False,
-            )
-            session.add(new_chat)
-            await session.commit()
-            logger.info(
-                f"Чат {chat_id} ({chat_title}) добавлен в базу данных пользователем {added_by}."
-            )
-        except Exception as e:
-            await session.rollback()
-            logger.error(f"Ошибка при добавлении чата {chat_id}: {e}")
-            raise
+                new_chat = Chat(
+                    chat_id=str(chat_id),
+                    title=chat_title,
+                    added_by=added_by,
+                    added_at=datetime.now(),
+                    deleted=False,
+                )
+                session.add(new_chat)
+                await session.commit()
+                logger.info(
+                    f"Чат {chat_id} ({chat_title}) добавлен в базу данных пользователем {added_by}."
+                )
+        else:
+            # synchronous session (used in tests)
+            try:
+                result = session.query(Chat).filter(Chat.chat_id == str(chat_id)).first()
+                if result:
+                    if result.deleted:
+                        result.deleted = False
+                        result.deleted_by = None
+                        result.deleted_at = None
+                        session.commit()
+                        logger.info(f"Чат {chat_id} восстановлен.")
+                    else:
+                        logger.debug(
+                            f"Чат {chat_id} уже существует в базе данных."
+                        )
+                    return
+                new_chat = Chat(
+                    chat_id=str(chat_id),
+                    title=chat_title,
+                    added_by=added_by,
+                    added_at=datetime.now(),
+                    deleted=False,
+                )
+                session.add(new_chat)
+                session.commit()
+                logger.info(
+                    f"Чат {chat_id} ({chat_title}) добавлен в базу данных пользователем {added_by}."
+                )
+            except Exception as e:
+                session.rollback()
+                logger.error(f"Ошибка при добавлении чата {chat_id}: {e}")
+                raise
+    except Exception:
+        raise
+    finally:
+        if isinstance(session, AsyncSession):
+            await session.close()
+        else:
+            session.close()
 
 
-async def remove_chat(chat_id: int, removed_by: str) -> bool:
+async def remove_chat_async(chat_id: int, removed_by: str) -> bool:
     """
     Помечает чат как удалённый в базе данных.
 
@@ -65,12 +108,33 @@ async def remove_chat(chat_id: int, removed_by: str) -> bool:
     :param removed_by: Имя или username пользователя, инициировавшего удаление.
     :return: True, если чат найден и успешно помечен, иначе False.
     """
-    async with SessionLocal() as session:
-        try:
-            result = await session.execute(
-                select(Chat).filter(Chat.chat_id == str(chat_id))
-            )
-            chat = result.scalars().first()
+    session = SessionLocal()
+    try:
+        if isinstance(session, AsyncSession):
+            async with session:
+                result = await session.execute(
+                    select(Chat).filter(Chat.chat_id == str(chat_id))
+                )
+                chat = result.scalars().first()
+                if not chat:
+                    logger.debug(f"Чат {chat_id} не найден в базе данных.")
+                    return False
+                if chat.deleted:
+                    logger.debug(
+                        f"Чат {chat_id} ({chat.title}) уже помечен как удалённый."
+                    )
+                    return False
+
+                chat.deleted = True
+                chat.deleted_by = removed_by
+                chat.deleted_at = datetime.utcnow()
+                await session.commit()
+                logger.info(
+                    f"Чат {chat_id} ({chat.title}) помечен как удалённый пользователем {removed_by}."
+                )
+                return True
+        else:
+            chat = session.query(Chat).filter(Chat.chat_id == str(chat_id)).first()
             if not chat:
                 logger.debug(f"Чат {chat_id} не найден в базе данных.")
                 return False
@@ -83,15 +147,23 @@ async def remove_chat(chat_id: int, removed_by: str) -> bool:
             chat.deleted = True
             chat.deleted_by = removed_by
             chat.deleted_at = datetime.utcnow()
-            await session.commit()
+            session.commit()
             logger.info(
                 f"Чат {chat_id} ({chat.title}) помечен как удалённый пользователем {removed_by}."
             )
             return True
-        except Exception as e:
+    except Exception as e:
+        if isinstance(session, AsyncSession):
             await session.rollback()
-            logger.error(f"Ошибка при удалении чата {chat_id}: {e}")
-            return False
+        else:
+            session.rollback()
+        logger.error(f"Ошибка при удалении чата {chat_id}: {e}")
+        return False
+    finally:
+        if isinstance(session, AsyncSession):
+            await session.close()
+        else:
+            session.close()
 
 
 async def is_user_admin(message: Message) -> bool:
@@ -111,21 +183,48 @@ async def is_user_admin(message: Message) -> bool:
         return False
 
 
-async def get_all_chats():
-    async with SessionLocal() as session:
-        try:
-            result = await session.execute(select(Chat))
-            chats = result.scalars().all()
-            result_list = []
-            for chat in chats:
-                result_list.append(
-                    {
-                        "chat_id": chat.chat_id,
-                        "title": chat.title,
-                        "deleted": chat.deleted,
-                    }
-                )
-            return result_list
-        except Exception as e:
-            logger.error(f"Ошибка при получении списка чатов: {e}")
-            return []
+async def get_all_chats_async():
+    session = SessionLocal()
+    try:
+        if isinstance(session, AsyncSession):
+            async with session:
+                result = await session.execute(select(Chat))
+                chats = result.scalars().all()
+        else:
+            chats = session.query(Chat).all()
+
+        result_list = []
+        for chat in chats:
+            result_list.append(
+                {
+                    "chat_id": chat.chat_id,
+                    "title": chat.title,
+                    "deleted": chat.deleted,
+                }
+            )
+        return result_list
+    except Exception as e:
+        logger.error(f"Ошибка при получении списка чатов: {e}")
+        return []
+    finally:
+        if isinstance(session, AsyncSession):
+            await session.close()
+        else:
+            session.close()
+
+
+# ---------------------------------------------------------------------------
+# Synchronous wrappers for tests and other synchronous use-cases
+# ---------------------------------------------------------------------------
+
+
+def add_chat(chat_id: int, chat_title: str, added_by: str) -> None:
+    asyncio.run(add_chat_async(chat_id, chat_title, added_by))
+
+
+def remove_chat(chat_id: int, removed_by: str) -> bool:
+    return asyncio.run(remove_chat_async(chat_id, removed_by))
+
+
+def get_all_chats():
+    return asyncio.run(get_all_chats_async())


### PR DESCRIPTION
## Summary
- Support both async and sync database sessions in chat manager
- Provide synchronous wrappers for add/remove/list chat utilities
- Update command handlers to use new async chat manager functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71690b55c83298be76e2030c2ed72