### PR TITLE
refactor: migrate database utilities to async style

### DIFF
--- a/bot/commands/announce.py
+++ b/bot/commands/announce.py
@@ -9,6 +9,7 @@ from aiogram.fsm.state import StatesGroup, State
 from bot.config.flags import ANNOUNCE_ENABLE
 from bot.database import SessionLocal
 from bot.models import Chat
+from sqlalchemy import select
 
 logger = logging.getLogger(__name__)
 router = Router()
@@ -56,17 +57,20 @@ async def send_announce_to_chat(chat: Dict[str, Any],
                        f"{chat['id']} ({chat['title']}): {e}")
 
 
-async def process_announce(message: types.Message,
-                           announce_message: Optional[str],
-                           reply_to_message: Optional[types.Message]) -> None:
-    session = SessionLocal()
-    try:
-        chat_list_db = session.query(Chat).filter(Chat.deleted.is_(False)).all()
-    except Exception as e:
-        logger.error("Ошибка получения списка чатов: %s", e)
-        chat_list_db = []
-    finally:
-        session.close()
+async def process_announce(
+    message: types.Message,
+    announce_message: Optional[str],
+    reply_to_message: Optional[types.Message],
+) -> None:
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(Chat).filter(Chat.deleted.is_(False))
+            )
+            chat_list_db = result.scalars().all()
+        except Exception as e:
+            logger.error("Ошибка получения списка чатов: %s", e)
+            chat_list_db = []
 
     if not chat_list_db:
         await message.answer("Нет активных чатов для отправки.")

--- a/bot/commands/best_qa.py
+++ b/bot/commands/best_qa.py
@@ -21,8 +21,8 @@ async def handle_best_qa(message: Message) -> None:
 
     chat_id = str(message.chat.id)
     # Если уже выбран победитель сегодня, уведомляем об этом
-    if not is_new_day(chat_id):
-        last = get_last_winner(chat_id)
+    if not await is_new_day(chat_id):
+        last = await get_last_winner(chat_id)
         if last:
             mention = format_winner_mention(last.winner_user_id,
                                             last.winner_full_name)
@@ -31,19 +31,19 @@ async def handle_best_qa(message: Message) -> None:
                                  parse_mode="HTML")
         return
 
-    participant = get_random_participant(chat_id)
+    participant = await get_random_participant(chat_id)
     if not participant:
         await message.answer("Не нашёл участников для выбора.")
         return
 
-    update_last_winner(
+    await update_last_winner(
         chat_id,
         message.chat.title or "Личный чат",
         str(participant.user_id),
         participant.full_name,
         participant.username
     )
-    update_winner_stats(
+    await update_winner_stats(
         chat_id,
         message.chat.title or "Личный чат",
         str(participant.user_id),

--- a/bot/commands/best_qa_stat.py
+++ b/bot/commands/best_qa_stat.py
@@ -4,29 +4,29 @@ from aiogram.types import Message
 from bot.config.flags import BEST_QA_STAT_ENABLE
 from bot.database import SessionLocal
 from bot.models import WinnerStats
+from sqlalchemy import select
 from bot.utils.game_engine import format_declension
 from bot.config.logging import setup_logging
 
 setup_logging()
 
 
-def get_stats(chat_id: str) -> list:
+async def get_stats(chat_id: str) -> list:
     """
     Получает статистику победителей для заданного чата из базы данных,
     сортируя записи по количеству побед (от большего к меньшему).
     """
-    session = SessionLocal()
-    try:
-        stats = session.query(WinnerStats) \
-            .filter(WinnerStats.chat_id == chat_id) \
-            .order_by(WinnerStats.wins.desc()) \
-            .all()
-        return stats
-    except Exception as e:
-        logging.error("Ошибка получения статистики: %s", e)
-        return []
-    finally:
-        session.close()
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(WinnerStats)
+                .filter(WinnerStats.chat_id == chat_id)
+                .order_by(WinnerStats.wins.desc())
+            )
+            return result.scalars().all()
+        except Exception as e:
+            logging.error("Ошибка получения статистики: %s", e)
+            return []
 
 
 def format_stats(message: Message, stats: list) -> str:
@@ -53,7 +53,7 @@ async def handle_best_qa_stat(message: Message) -> None:
         return
 
     chat_id = str(message.chat.id)
-    stats = get_stats(chat_id)
+    stats = await get_stats(chat_id)
     if not stats:
         await message.answer("Статистика по лучшим тестировщикам пока пуста.")
         return

--- a/bot/commands/get_access.py
+++ b/bot/commands/get_access.py
@@ -8,6 +8,7 @@ from bot.database import SessionLocal
 from bot.models import AdminUser
 from bot.config.flags import GET_ACCESS_ENABLE
 from bot.config.tokens import ADMIN_USER_ID
+from sqlalchemy import select
 
 
 logger = logging.getLogger(__name__)
@@ -15,18 +16,19 @@ router = Router()
 
 
 async def access_already_granted(message: types.Message):
-    session = SessionLocal()
-    try:
-        record = session.query(AdminUser).filter(
-            AdminUser.user_id == str(message.from_user.id),
-            AdminUser.is_active.is_(True)
-        ).first()
-        return record is not None
-    except Exception as e:
-        logger.error("Ошибка проверки доступа: %s", e)
-        return False
-    finally:
-        session.close()
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(AdminUser).filter(
+                    AdminUser.user_id == str(message.from_user.id),
+                    AdminUser.is_active.is_(True),
+                )
+            )
+            record = result.scalars().first()
+            return record is not None
+        except Exception as e:
+            logger.error("Ошибка проверки доступа: %s", e)
+            return False
 
 
 def prepare_admin_request(message: types.Message) \
@@ -81,40 +83,38 @@ async def handle_get_access(message: types.Message) -> None:
                              "администратору. Попробуйте позже.")
 
 
-async def handle_accept_callback(callback: types.CallbackQuery,
-                                 user_id_str: str,
-                                 target_user_id: int) \
-        -> None:
-    session = SessionLocal()
-    try:
-        admin_record = session.query(AdminUser).filter(
-            AdminUser.user_id == user_id_str
-        ).first()
-        if not admin_record:
-            admin_record = AdminUser(
-                user_id=user_id_str,
-                full_name=callback.from_user.full_name,
-                username=callback.from_user.username or "",
-                added_at=datetime.utcnow(),
-                is_active=True
+async def handle_accept_callback(
+    callback: types.CallbackQuery, user_id_str: str, target_user_id: int
+) -> None:
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(AdminUser).filter(AdminUser.user_id == user_id_str)
             )
-            session.add(admin_record)
-            session.commit()
-        else:
-            if not admin_record.is_active:
-                admin_record.is_active = True
-                admin_record.added_at = datetime.utcnow()
-                session.commit()
-        await callback.message.edit_reply_markup(reply_markup=None)
-        await callback.bot.send_message(chat_id=target_user_id,
-                                        text="Доступ предоставлен")
-        await callback.answer("Доступ предоставлен.")
-    except Exception as e:
-        session.rollback()
-        logger.error("Ошибка обработки accept callback: %s", e)
-        await callback.answer("Произошла ошибка. Попробуйте позже.")
-    finally:
-        session.close()
+            admin_record = result.scalars().first()
+            if not admin_record:
+                admin_record = AdminUser(
+                    user_id=user_id_str,
+                    full_name=callback.from_user.full_name,
+                    username=callback.from_user.username or "",
+                    added_at=datetime.utcnow(),
+                    is_active=True,
+                )
+                session.add(admin_record)
+            else:
+                if not admin_record.is_active:
+                    admin_record.is_active = True
+                    admin_record.added_at = datetime.utcnow()
+            await session.commit()
+            await callback.message.edit_reply_markup(reply_markup=None)
+            await callback.bot.send_message(
+                chat_id=target_user_id, text="Доступ предоставлен"
+            )
+            await callback.answer("Доступ предоставлен.")
+        except Exception as e:
+            await session.rollback()
+            logger.error("Ошибка обработки accept callback: %s", e)
+            await callback.answer("Произошла ошибка. Попробуйте позже.")
 
 
 async def handle_decline_callback(callback: types.CallbackQuery,

--- a/bot/commands/help.py
+++ b/bot/commands/help.py
@@ -4,33 +4,35 @@ from aiogram.types import Message
 from bot.modules.commands_list import get_all_commands
 from bot.database import SessionLocal
 from bot.models import AdminUser
+from sqlalchemy import select
 
 logger = logging.getLogger(__name__)
 
 
-def is_user_admin_db(user_id: int) -> bool:
+async def is_user_admin_db(user_id: int) -> bool:
     """
     Проверяет, является ли пользователь администратором,
     запрашивая наличие активной записи в таблице admin_users.
     """
-    session = SessionLocal()
-    try:
-        admin_record = session.query(AdminUser).filter(
-            AdminUser.user_id == str(user_id),
-            AdminUser.is_active.is_(True)
-        ).first()
-        return admin_record is not None
-    except Exception as e:
-        logger.error("Ошибка проверки админа в БД: %s", e)
-        return False
-    finally:
-        session.close()
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(AdminUser).filter(
+                    AdminUser.user_id == str(user_id),
+                    AdminUser.is_active.is_(True),
+                )
+            )
+            admin_record = result.scalars().first()
+            return admin_record is not None
+        except Exception as e:
+            logger.error("Ошибка проверки админа в БД: %s", e)
+            return False
 
 
 async def handle_help(message: Message):
     # Определяем, является ли пользователь администратором,
     # проверяя запись в БД.
-    user_is_admin = is_user_admin_db(message.from_user.id)
+    user_is_admin = await is_user_admin_db(message.from_user.id)
 
     # Получаем полный список команд с учетом прав пользователя.
     commands = get_all_commands(user_is_admin=user_is_admin)

--- a/bot/commands/search.py
+++ b/bot/commands/search.py
@@ -11,6 +11,7 @@ from aiogram.fsm.state import StatesGroup, State
 from bot.config.tokens import OPENAI_API_KEY
 from bot.config.gpt_prompt import PROMPT
 from bot.config.logging import setup_logging
+from bot.database import SessionLocal
 
 setup_logging()
 
@@ -74,7 +75,7 @@ async def process_immediate_query(user_query: str,
     Записывает запрос в базу, отправляет сообщение "Обрабатываю ваш запрос...",
     вызывает ChatGPT и отправляет результат в чат.
     """
-    log_search_request_db(message, user_query)
+    await log_search_request_db(message, user_query)
     await message.answer("Обрабатываю ваш запрос...")
     answer: str = await query_openai(user_query, message)
     await message.answer(answer)
@@ -138,28 +139,25 @@ async def process_search_query(message: types.Message,
     await process_immediate_query(user_query, message, state)
 
 
-def log_search_request_db(message: types.Message, user_query: str) -> None:
-    """
-    Логирует запрос пользователя в базу данных (таблица search_logs).
-    """
-    from bot.database import SessionLocal
+async def log_search_request_db(message: types.Message, user_query: str) -> None:
+    """Логирует запрос пользователя в базу данных (таблица search_logs)."""
     from bot.models import SearchLog
-    session = SessionLocal()
-    try:
-        log_entry = SearchLog(
-            user_id=str(message.from_user.id),
-            username=message.from_user.username or "",
-            full_name=message.from_user.full_name,
-            query=user_query,
-            timestamp=message.date  # или можно использовать datetime.utcnow()
-        )
-        session.add(log_entry)
-        session.commit()
-    except Exception as e:
-        session.rollback()
-        logging.error("Ошибка при записи лога запроса в базу данных: %s", e)
-    finally:
-        session.close()
+    async with SessionLocal() as session:
+        try:
+            log_entry = SearchLog(
+                user_id=str(message.from_user.id),
+                username=message.from_user.username or "",
+                full_name=message.from_user.full_name,
+                query=user_query,
+                timestamp=message.date,  # или можно использовать datetime.utcnow()
+            )
+            session.add(log_entry)
+            await session.commit()
+        except Exception as e:
+            await session.rollback()
+            logging.error(
+                "Ошибка при записи лога запроса в базу данных: %s", e
+            )
 
 
 async def query_openai(user_query: str, message: types.Message) -> str:

--- a/bot/messages/messages.py
+++ b/bot/messages/messages.py
@@ -60,7 +60,7 @@ async def handle_message(message: Message, state: FSMContext) -> None:
     text: str = message.text.strip()
 
     # Обновляем или добавляем участника в БД на основе сообщения
-    update_participant(message)
+    await update_participant(message)
 
     # Обработка дополнительных фановых триггеров
     await handle_bot_tag(message, BOT_USERNAME, flag.BOT_TAG_ENABLE)

--- a/bot/utils/chat_manager.py
+++ b/bot/utils/chat_manager.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from aiogram.types import Message
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from bot.database import SessionLocal
 from bot.models import Chat
@@ -12,129 +11,53 @@ from bot.models import Chat
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Asynchronous implementations
-# ---------------------------------------------------------------------------
-
-
 async def add_chat_async(chat_id: int, chat_title: str, added_by: str) -> None:
-    """
-    Добавляет чат в базу данных или восстанавливает его,
-    если он ранее был помечен как удалённый.
+    """Добавляет чат в базу данных или восстанавливает его, если он был удалён."""
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(Chat).filter(Chat.chat_id == str(chat_id))
+            )
+            existing_chat = result.scalars().first()
+            if existing_chat:
+                if existing_chat.deleted:
+                    existing_chat.deleted = False
+                    existing_chat.deleted_by = None
+                    existing_chat.deleted_at = None
+                    await session.commit()
+                    logger.info(f"Чат {chat_id} восстановлен.")
+                else:
+                    logger.debug(
+                        f"Чат {chat_id} уже существует в базе данных."
+                    )
+                return
 
-    :param chat_id: Идентификатор чата.
-    :param chat_title: Название чата.
-    :param added_by: Имя или username пользователя, добавившего чат.
-    """
-    session = SessionLocal()
-    try:
-        if isinstance(session, AsyncSession):
-            async with session:
-                result = await session.execute(
-                    select(Chat).filter(Chat.chat_id == str(chat_id))
-                )
-                existing_chat = result.scalars().first()
-                if existing_chat:
-                    if existing_chat.deleted:
-                        existing_chat.deleted = False
-                        existing_chat.deleted_by = None
-                        existing_chat.deleted_at = None
-                        await session.commit()
-                        logger.info(f"Чат {chat_id} восстановлен.")
-                    else:
-                        logger.debug(
-                            f"Чат {chat_id} уже существует в базе данных."
-                        )
-                    return
-
-                new_chat = Chat(
-                    chat_id=str(chat_id),
-                    title=chat_title,
-                    added_by=added_by,
-                    added_at=datetime.now(),
-                    deleted=False,
-                )
-                session.add(new_chat)
-                await session.commit()
-                logger.info(
-                    f"Чат {chat_id} ({chat_title}) добавлен в базу данных пользователем {added_by}."
-                )
-        else:
-            # synchronous session (used in tests)
-            try:
-                result = session.query(Chat).filter(Chat.chat_id == str(chat_id)).first()
-                if result:
-                    if result.deleted:
-                        result.deleted = False
-                        result.deleted_by = None
-                        result.deleted_at = None
-                        session.commit()
-                        logger.info(f"Чат {chat_id} восстановлен.")
-                    else:
-                        logger.debug(
-                            f"Чат {chat_id} уже существует в базе данных."
-                        )
-                    return
-                new_chat = Chat(
-                    chat_id=str(chat_id),
-                    title=chat_title,
-                    added_by=added_by,
-                    added_at=datetime.now(),
-                    deleted=False,
-                )
-                session.add(new_chat)
-                session.commit()
-                logger.info(
-                    f"Чат {chat_id} ({chat_title}) добавлен в базу данных пользователем {added_by}."
-                )
-            except Exception as e:
-                session.rollback()
-                logger.error(f"Ошибка при добавлении чата {chat_id}: {e}")
-                raise
-    except Exception:
-        raise
-    finally:
-        if isinstance(session, AsyncSession):
-            await session.close()
-        else:
-            session.close()
+            new_chat = Chat(
+                chat_id=str(chat_id),
+                title=chat_title,
+                added_by=added_by,
+                added_at=datetime.now(),
+                deleted=False,
+            )
+            session.add(new_chat)
+            await session.commit()
+            logger.info(
+                f"Чат {chat_id} ({chat_title}) добавлен в базу данных пользователем {added_by}."
+            )
+        except Exception as e:
+            await session.rollback()
+            logger.error(f"Ошибка при добавлении чата {chat_id}: {e}")
+            raise
 
 
 async def remove_chat_async(chat_id: int, removed_by: str) -> bool:
-    """
-    Помечает чат как удалённый в базе данных.
-
-    :param chat_id: Идентификатор чата.
-    :param removed_by: Имя или username пользователя, инициировавшего удаление.
-    :return: True, если чат найден и успешно помечен, иначе False.
-    """
-    session = SessionLocal()
-    try:
-        if isinstance(session, AsyncSession):
-            async with session:
-                result = await session.execute(
-                    select(Chat).filter(Chat.chat_id == str(chat_id))
-                )
-                chat = result.scalars().first()
-                if not chat:
-                    logger.debug(f"Чат {chat_id} не найден в базе данных.")
-                    return False
-                if chat.deleted:
-                    logger.debug(
-                        f"Чат {chat_id} ({chat.title}) уже помечен как удалённый."
-                    )
-                    return False
-
-                chat.deleted = True
-                chat.deleted_by = removed_by
-                chat.deleted_at = datetime.utcnow()
-                await session.commit()
-                logger.info(
-                    f"Чат {chat_id} ({chat.title}) помечен как удалённый пользователем {removed_by}."
-                )
-                return True
-        else:
-            chat = session.query(Chat).filter(Chat.chat_id == str(chat_id)).first()
+    """Помечает чат как удалённый."""
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(Chat).filter(Chat.chat_id == str(chat_id))
+            )
+            chat = result.scalars().first()
             if not chat:
                 logger.debug(f"Чат {chat_id} не найден в базе данных.")
                 return False
@@ -147,70 +70,49 @@ async def remove_chat_async(chat_id: int, removed_by: str) -> bool:
             chat.deleted = True
             chat.deleted_by = removed_by
             chat.deleted_at = datetime.utcnow()
-            session.commit()
+            await session.commit()
             logger.info(
                 f"Чат {chat_id} ({chat.title}) помечен как удалённый пользователем {removed_by}."
             )
             return True
-    except Exception as e:
-        if isinstance(session, AsyncSession):
+        except Exception as e:
             await session.rollback()
-        else:
-            session.rollback()
-        logger.error(f"Ошибка при удалении чата {chat_id}: {e}")
-        return False
-    finally:
-        if isinstance(session, AsyncSession):
-            await session.close()
-        else:
-            session.close()
+            logger.error(f"Ошибка при удалении чата {chat_id}: {e}")
+            return False
 
 
 async def is_user_admin(message: Message) -> bool:
-    """
-    Проверяет, является ли пользователь администратором чата.
-
-    :param message: Объект сообщения.
-    :return: True, если пользователь является администратором, иначе False.
-    """
+    """Проверяет, является ли пользователь администратором чата."""
     try:
         chat_administrators = await message.bot.get_chat_administrators(
-            message.chat.id)
-        return any(admin.user.id == message.from_user.id
-                   for admin in chat_administrators)
+            message.chat.id
+        )
+        return any(
+            admin.user.id == message.from_user.id for admin in chat_administrators
+        )
     except Exception as e:
         logger.error(f"Ошибка при проверке администратора: {e}")
         return False
 
 
 async def get_all_chats_async():
-    session = SessionLocal()
-    try:
-        if isinstance(session, AsyncSession):
-            async with session:
-                result = await session.execute(select(Chat))
-                chats = result.scalars().all()
-        else:
-            chats = session.query(Chat).all()
-
-        result_list = []
-        for chat in chats:
-            result_list.append(
-                {
-                    "chat_id": chat.chat_id,
-                    "title": chat.title,
-                    "deleted": chat.deleted,
-                }
-            )
-        return result_list
-    except Exception as e:
-        logger.error(f"Ошибка при получении списка чатов: {e}")
-        return []
-    finally:
-        if isinstance(session, AsyncSession):
-            await session.close()
-        else:
-            session.close()
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(select(Chat))
+            chats = result.scalars().all()
+            result_list = []
+            for chat in chats:
+                result_list.append(
+                    {
+                        "chat_id": chat.chat_id,
+                        "title": chat.title,
+                        "deleted": chat.deleted,
+                    }
+                )
+            return result_list
+        except Exception as e:
+            logger.error(f"Ошибка при получении списка чатов: {e}")
+            return []
 
 
 # ---------------------------------------------------------------------------
@@ -228,3 +130,4 @@ def remove_chat(chat_id: int, removed_by: str) -> bool:
 
 def get_all_chats():
     return asyncio.run(get_all_chats_async())
+

--- a/bot/utils/game_engine.py
+++ b/bot/utils/game_engine.py
@@ -1,7 +1,9 @@
 import random
 import logging
 from datetime import datetime, timezone
+
 from aiogram.utils.markdown import hlink
+from sqlalchemy import select
 
 from bot.database import SessionLocal
 from bot.models import LastWinner, WinnerStats, Participant
@@ -9,114 +11,110 @@ from bot.models import LastWinner, WinnerStats, Participant
 logger = logging.getLogger(__name__)
 
 
-def update_last_winner(chat_id: str,
-                       chat_title: str,
-                       user_id: str,
-                       full_name: str,
-                       username: str) -> None:
-    """Обновляет или создаёт запись о последнем
-    победителе для заданного чата."""
-    session = SessionLocal()
-    try:
-        last = (session.query(LastWinner)
-                .filter(LastWinner.chat_id == chat_id).first())
-        now = datetime.now(timezone.utc)
-        if last is None:
-            last = LastWinner(
-                chat_id=chat_id,
-                chat_title=chat_title,
-                last_datetime=now,
-                winner_user_id=user_id,
-                winner_full_name=full_name,
-                winner_username=username or ""
+async def update_last_winner(
+    chat_id: str,
+    chat_title: str,
+    user_id: str,
+    full_name: str,
+    username: str,
+) -> None:
+    """Обновляет или создаёт запись о последнем победителе для заданного чата."""
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(LastWinner).filter(LastWinner.chat_id == chat_id)
             )
-            session.add(last)
-        else:
-            last.chat_title = chat_title
-            last.last_datetime = now
-            last.winner_user_id = user_id
-            last.winner_full_name = full_name
-            last.winner_username = username or ""
-        session.commit()
-    except Exception as e:
-        session.rollback()
-        logger.error("Ошибка обновления последнего победителя: %s", e)
-        raise
-    finally:
-        session.close()
+            last = result.scalars().first()
+            now = datetime.now(timezone.utc)
+            if last is None:
+                last = LastWinner(
+                    chat_id=chat_id,
+                    chat_title=chat_title,
+                    last_datetime=now,
+                    winner_user_id=user_id,
+                    winner_full_name=full_name,
+                    winner_username=username or "",
+                )
+                session.add(last)
+            else:
+                last.chat_title = chat_title
+                last.last_datetime = now
+                last.winner_user_id = user_id
+                last.winner_full_name = full_name
+                last.winner_username = username or ""
+            await session.commit()
+        except Exception as e:
+            await session.rollback()
+            logger.error("Ошибка обновления последнего победителя: %s", e)
+            raise
 
 
-def update_winner_stats(chat_id: str,
-                        chat_title: str,
-                        user_id: str,
-                        full_name: str,
-                        username: str) -> None:
+async def update_winner_stats(
+    chat_id: str,
+    chat_title: str,
+    user_id: str,
+    full_name: str,
+    username: str,
+) -> None:
     """Обновляет статистику побед для пользователя в заданном чате."""
-    session = SessionLocal()
-    try:
-        stats = session.query(WinnerStats).filter(
-            WinnerStats.chat_id == chat_id,
-            WinnerStats.user_id == user_id
-        ).first()
-        if stats is None:
-            stats = WinnerStats(
-                chat_id=chat_id,
-                chat_title=chat_title,
-                user_id=user_id,
-                full_name=full_name,
-                username=username or "",
-                wins=1
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(WinnerStats).filter(
+                    WinnerStats.chat_id == chat_id, WinnerStats.user_id == user_id
+                )
             )
-            session.add(stats)
-        else:
-            stats.wins += 1
-        session.commit()
-    except Exception as e:
-        session.rollback()
-        logger.error("Ошибка обновления статистики побед: %s", e)
-        raise
-    finally:
-        session.close()
+            stats = result.scalars().first()
+            if stats is None:
+                stats = WinnerStats(
+                    chat_id=chat_id,
+                    chat_title=chat_title,
+                    user_id=user_id,
+                    full_name=full_name,
+                    username=username or "",
+                    wins=1,
+                )
+                session.add(stats)
+            else:
+                stats.wins += 1
+            await session.commit()
+        except Exception as e:
+            await session.rollback()
+            logger.error("Ошибка обновления статистики побед: %s", e)
+            raise
 
 
-def get_last_winner(chat_id: str):
-    """Возвращает запись о последнем победителе
-    для заданного чата (или None)."""
-    session = SessionLocal()
-    try:
-        return (session.query(LastWinner)
-                .filter(LastWinner.chat_id == chat_id).first())
-    finally:
-        session.close()
+async def get_last_winner(chat_id: str):
+    """Возвращает запись о последнем победителе для заданного чата (или None)."""
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(LastWinner).filter(LastWinner.chat_id == chat_id)
+        )
+        return result.scalars().first()
 
 
-def is_new_day(chat_id: str) -> bool:
-    """Возвращает True, если текущая дата позже
-    даты последнего выбора победителя."""
-    last = get_last_winner(chat_id)
+async def is_new_day(chat_id: str) -> bool:
+    """Возвращает True, если текущая дата позже даты последнего выбора победителя."""
+    last = await get_last_winner(chat_id)
     if not last:
         return True
     return datetime.now(timezone.utc).date() > last.last_datetime.date()
-    # return True
 
 
-def get_random_participant(chat_id: str):
-    """Возвращает случайного участника из таблицы
-    участников для заданного чата."""
-    session = SessionLocal()
-    try:
-        participants = (session.query(Participant)
-                        .filter(Participant.chat_id == chat_id).all())
-    finally:
-        session.close()
+async def get_random_participant(chat_id: str):
+    """Возвращает случайного участника из таблицы участников для заданного чата."""
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(Participant).filter(Participant.chat_id == chat_id)
+        )
+        participants = result.scalars().all()
     if participants:
         return random.choice(participants)
     return None
 
 
 def format_declension(wins: int) -> str:
-    """Возвращает правильную форму слова 'победа'
-    в зависимости от числа wins."""
+    """Возвращает правильную форму слова 'победа' в зависимости от числа wins."""
     if wins % 10 == 1 and wins % 100 != 11:
         return "победа"
     elif wins % 10 in [2, 3, 4] and not (wins % 100 in [12, 13, 14]):
@@ -128,3 +126,4 @@ def format_declension(wins: int) -> str:
 def format_winner_mention(user_id: str, full_name: str) -> str:
     """Формирует строку для упоминания пользователя."""
     return hlink(full_name, f"tg://user?id={user_id}")
+

--- a/bot/utils/participants.py
+++ b/bot/utils/participants.py
@@ -1,48 +1,55 @@
 import logging
 from datetime import datetime
+
+from sqlalchemy import select
+
 from bot.database import SessionLocal
 from bot.models import Participant
 
 
-def update_participant(message) -> None:
+async def update_participant(message) -> None:
     # Если сообщение пришло из личного чата, не добавляем участника
     if message.chat.type == "private":
-        logging.debug("Сообщение из личного чата: "
-                      "участник не добавляется в таблицу.")
+        logging.debug(
+            "Сообщение из личного чата: участник не добавляется в таблицу."
+        )
         return
 
     user = message.from_user
     chat_id = str(message.chat.id)
-    session = SessionLocal()
-    try:
-        participant = session.query(Participant).filter(
-            Participant.chat_id == chat_id,
-            Participant.user_id == str(user.id)
-        ).first()
-
-        if participant is None:
-            # Создаем новую запись для участника с названием чата
-            participant = Participant(
-                chat_id=chat_id,
-                user_id=str(user.id),
-                full_name=user.full_name,
-                username=user.username or "",
-                chat_title=message.chat.title or ""
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(Participant).filter(
+                    Participant.chat_id == chat_id,
+                    Participant.user_id == str(user.id),
+                )
             )
-            session.add(participant)
-            session.commit()
-            logging.info(f"Добавлен новый участник: {user.full_name} "
-                         f"(ID: {user.id}) в чат {chat_id}")
-        else:
-            # Обновляем время последней активности и
-            # название чата (на случай, если оно изменилось)
-            participant.last_active = datetime.utcnow()
-            participant.chat_title = message.chat.title or ""
-            session.commit()
-            logging.debug(f"Обновлена активность участника: {user.full_name} "
-                          f"(ID: {user.id}) в чат {chat_id}")
-    except Exception as e:
-        session.rollback()
-        logging.error(f"Ошибка при обновлении участника: {e}")
-    finally:
-        session.close()
+            participant = result.scalars().first()
+
+            if participant is None:
+                # Создаем новую запись для участника с названием чата
+                participant = Participant(
+                    chat_id=chat_id,
+                    user_id=str(user.id),
+                    full_name=user.full_name,
+                    username=user.username or "",
+                    chat_title=message.chat.title or "",
+                )
+                session.add(participant)
+                await session.commit()
+                logging.info(
+                    f"Добавлен новый участник: {user.full_name} (ID: {user.id}) в чат {chat_id}"
+                )
+            else:
+                # Обновляем время последней активности и название чата (на случай, если оно изменилось)
+                participant.last_active = datetime.utcnow()
+                participant.chat_title = message.chat.title or ""
+                await session.commit()
+                logging.debug(
+                    f"Обновлена активность участника: {user.full_name} (ID: {user.id}) в чат {chat_id}"
+                )
+        except Exception as e:
+            await session.rollback()
+            logging.error(f"Ошибка при обновлении участника: {e}")
+

--- a/tests/test_commands_async.py
+++ b/tests/test_commands_async.py
@@ -17,7 +17,7 @@ async def test_process_immediate_query(monkeypatch):
     async def fake_query_openai(user_query, message):
         return "result"
 
-    def fake_log_search_request_db(message, user_query):
+    async def fake_log_search_request_db(message, user_query):
         pass
 
     monkeypatch.setattr(search, "query_openai", fake_query_openai)
@@ -42,24 +42,29 @@ async def test_handle_best_qa(monkeypatch):
         answer=AsyncMock()
     )
 
-    monkeypatch.setattr(best_qa, "is_new_day", lambda chat_id: True)
+    async def fake_is_new_day(chat_id):
+        return True
+
+    monkeypatch.setattr(best_qa, "is_new_day", fake_is_new_day)
     participant = SimpleNamespace(
         user_id="1", full_name="User", username="user"
     )
+
+    async def fake_get_random_participant(chat_id):
+        return participant
+
     monkeypatch.setattr(
-        best_qa, "get_random_participant", lambda chat_id: participant
+        best_qa, "get_random_participant", fake_get_random_participant
     )
     flags = {"lw": False, "ws": False}
-    monkeypatch.setattr(
-        best_qa,
-        "update_last_winner",
-        lambda *a, **k: flags.__setitem__("lw", True),
-    )
-    monkeypatch.setattr(
-        best_qa,
-        "update_winner_stats",
-        lambda *a, **k: flags.__setitem__("ws", True),
-    )
+    async def fake_update_last_winner(*a, **k):
+        flags["lw"] = True
+
+    async def fake_update_winner_stats(*a, **k):
+        flags["ws"] = True
+
+    monkeypatch.setattr(best_qa, "update_last_winner", fake_update_last_winner)
+    monkeypatch.setattr(best_qa, "update_winner_stats", fake_update_winner_stats)
     monkeypatch.setattr(
         best_qa,
         "format_winner_mention",

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,89 +1,97 @@
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy import select
 
 from bot.models import Chat, LastWinner, WinnerStats, Participant
 from bot.utils import chat_manager, game_engine
 from bot.database import Base
 
 
-@pytest.fixture
-def session_local(monkeypatch):
-    engine = create_engine(
-        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+@pytest_asyncio.fixture
+async def session_local(monkeypatch):
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", connect_args={"check_same_thread": False}
     )
-    TestingSessionLocal = sessionmaker(
-        bind=engine, autocommit=False, autoflush=False
-    )
-    Base.metadata.create_all(bind=engine)
+    TestingSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
     monkeypatch.setattr(chat_manager, "SessionLocal", TestingSessionLocal)
     monkeypatch.setattr(game_engine, "SessionLocal", TestingSessionLocal)
-    return TestingSessionLocal
+    yield TestingSessionLocal
+    await engine.dispose()
 
 
-def test_add_remove_get_chats(session_local):
-    chat_manager.add_chat(1, "Test Chat", "adder")
-    with session_local() as db:
-        chat = db.query(Chat).filter_by(chat_id="1").first()
+@pytest.mark.asyncio
+async def test_add_remove_get_chats(session_local):
+    await chat_manager.add_chat_async(1, "Test Chat", "adder")
+    async with session_local() as db:
+        result = await db.execute(select(Chat).filter(Chat.chat_id == "1"))
+        chat = result.scalars().first()
         assert chat is not None
         assert chat.title == "Test Chat"
         assert chat.added_by == "adder"
         assert chat.deleted is False
 
-    assert chat_manager.remove_chat(1, "remover") is True
-    assert chat_manager.remove_chat(1, "remover") is False
-    with session_local() as db:
-        chat = db.query(Chat).filter_by(chat_id="1").first()
+    assert await chat_manager.remove_chat_async(1, "remover") is True
+    assert await chat_manager.remove_chat_async(1, "remover") is False
+    async with session_local() as db:
+        result = await db.execute(select(Chat).filter(Chat.chat_id == "1"))
+        chat = result.scalars().first()
         assert chat.deleted is True
         assert chat.deleted_by == "remover"
 
-    chats = chat_manager.get_all_chats()
+    chats = await chat_manager.get_all_chats_async()
     assert {"chat_id": "1", "title": "Test Chat", "deleted": True} in chats
 
 
-def test_game_engine_updates_and_random(session_local):
-    # update_last_winner and is_new_day
-    game_engine.update_last_winner("1", "Chat", "u1", "User One", "user1")
-    assert game_engine.is_new_day("1") is False
-    with session_local() as db:
-        last = db.query(LastWinner).filter_by(chat_id="1").first()
+@pytest.mark.asyncio
+async def test_game_engine_updates_and_random(session_local):
+    await game_engine.update_last_winner("1", "Chat", "u1", "User One", "user1")
+    assert await game_engine.is_new_day("1") is False
+    async with session_local() as db:
+        result = await db.execute(select(LastWinner).filter(LastWinner.chat_id == "1"))
+        last = result.scalars().first()
         assert last.winner_user_id == "u1"
 
-    # update_winner_stats increments wins
-    game_engine.update_winner_stats("1", "Chat", "u1", "User One", "user1")
-    game_engine.update_winner_stats("1", "Chat", "u1", "User One", "user1")
-    with session_local() as db:
-        stats = (
-            db.query(WinnerStats)
-            .filter_by(chat_id="1", user_id="u1")
-            .first()
+    await game_engine.update_winner_stats("1", "Chat", "u1", "User One", "user1")
+    await game_engine.update_winner_stats("1", "Chat", "u1", "User One", "user1")
+    async with session_local() as db:
+        result = await db.execute(
+            select(WinnerStats).filter(
+                WinnerStats.chat_id == "1", WinnerStats.user_id == "u1"
+            )
         )
+        stats = result.scalars().first()
         assert stats.wins == 2
 
-    # get_random_participant returns one of inserted participants
-    with session_local() as db:
-        db.add_all([
-            Participant(
-                chat_id="1",
-                user_id="u1",
-                full_name="User One",
-                username="user1",
-            ),
-            Participant(
-                chat_id="1",
-                user_id="u2",
-                full_name="User Two",
-                username="user2",
-            ),
-        ])
-        db.commit()
-    participant = game_engine.get_random_participant("1")
+    async with session_local() as db:
+        db.add_all(
+            [
+                Participant(
+                    chat_id="1",
+                    user_id="u1",
+                    full_name="User One",
+                    username="user1",
+                ),
+                Participant(
+                    chat_id="1",
+                    user_id="u2",
+                    full_name="User Two",
+                    username="user2",
+                ),
+            ]
+        )
+        await db.commit()
+    participant = await game_engine.get_random_participant("1")
     assert participant.user_id in {"u1", "u2"}
 
-    # is_new_day becomes True when last_datetime is in the past
     from datetime import timedelta
-    with session_local() as db:
-        last = db.query(LastWinner).filter_by(chat_id="1").first()
+
+    async with session_local() as db:
+        result = await db.execute(select(LastWinner).filter(LastWinner.chat_id == "1"))
+        last = result.scalars().first()
         last.last_datetime = last.last_datetime - timedelta(days=1)
-        db.commit()
-    assert game_engine.is_new_day("1") is True
+        await db.commit()
+    assert await game_engine.is_new_day("1") is True
+


### PR DESCRIPTION
## Summary
- refactor game engine, participant updates and search logging to use async SQLAlchemy sessions
- update command handlers to await new async functions
- switch tests to async sessionmaker and pytest.asyncio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71ebb09d48329a67c217c0e86f1a4