### PR TITLE
refactor: centralize logging setup

### DIFF
--- a/bot/commands/add_chat.py
+++ b/bot/commands/add_chat.py
@@ -3,9 +3,6 @@ from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import ADD_CHAT_ENABLE
 from bot.utils.chat_manager import add_chat_async
-from bot.config.logging import setup_logging
-
-setup_logging()
 
 
 async def can_add_chat(message: Message) -> bool:

--- a/bot/commands/best_qa_stat.py
+++ b/bot/commands/best_qa_stat.py
@@ -6,9 +6,6 @@ from bot.database import SessionLocal
 from bot.models import WinnerStats
 from sqlalchemy import select
 from bot.utils.game_engine import format_declension
-from bot.config.logging import setup_logging
-
-setup_logging()
 
 
 async def get_stats(chat_id: str) -> list:

--- a/bot/commands/remove_chat.py
+++ b/bot/commands/remove_chat.py
@@ -3,9 +3,6 @@ from aiogram.filters import Command
 from aiogram.types import Message
 from bot.config.flags import REMOVE_CHAT_ENABLE
 from bot.utils.chat_manager import remove_chat_async
-from bot.config.logging import setup_logging
-
-setup_logging()
 
 
 async def handle_remove_chat(message: Message) -> None:

--- a/bot/commands/search.py
+++ b/bot/commands/search.py
@@ -10,10 +10,7 @@ from aiogram.fsm.state import StatesGroup, State
 
 from bot.config.tokens import OPENAI_API_KEY
 from bot.config.gpt_prompt import PROMPT
-from bot.config.logging import setup_logging
 from bot.database import SessionLocal
-
-setup_logging()
 
 openai.api_key = OPENAI_API_KEY
 router = Router()

--- a/bot/messages/message_parse.py
+++ b/bot/messages/message_parse.py
@@ -2,8 +2,6 @@ import re
 import logging
 from bot.dicts.links_dict import LINKS
 from bot.messages.errors_parse import build_error_defs
-from bot.config.logging import setup_logging
-
 from typing import List, Tuple
 
 
@@ -36,8 +34,6 @@ def should_skip(keyword: str) -> bool:
     return False
 
 
-# Настройка логирования
-setup_logging()
 
 
 def find_links_by_keyword(keyword: str, enabled: bool):


### PR DESCRIPTION
## Summary
- remove redundant logging configuration from command and message modules
- rely on run_bot to configure logging once at startup

## Testing
- `pytest -q`
- `python - <<'PY'
import importlib, logging
from bot.config.logging import setup_logging
setup_logging()
print('handlers before', len(logging.getLogger().handlers))
import bot.commands.add_chat as ac
importlib.reload(ac)
print('handlers after reload add_chat', len(logging.getLogger().handlers))
import bot.messages.message_parse as mp
importlib.reload(mp)
print('handlers after reload message_parse', len(logging.getLogger().handlers))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a727a9ab108329bf2ed3f8ecd4f9ee