### PR TITLE
Switch to async in-memory TTL cache

### DIFF
--- a/bot/messages/messages.py
+++ b/bot/messages/messages.py
@@ -124,7 +124,7 @@ async def process_results(message: Message, results: list) -> None:
     Обрабатывает результаты поиска ссылок.
     """
     filtered_results = (
-        filter_recent_links(message.chat.id, results)
+        await filter_recent_links(message.chat.id, results)
         if flag.TIMEOUT_RESPONSES_ENABLE
         else results
     )
@@ -136,7 +136,7 @@ async def process_results(message: Message, results: list) -> None:
         dislike_button = InlineKeyboardButton(text="👎 0", callback_data="dislike_init")
         keyboard = InlineKeyboardMarkup(inline_keyboard=[[like_button, dislike_button]], row_width=2)
         sent = await message.answer(response, reply_to_message_id=message.message_id, reply_markup=keyboard)
-        cache.init_reaction(sent.chat.id, sent.message_id, REACTION_TTL_SECONDS)
+        await cache.init_reaction(sent.chat.id, sent.message_id, REACTION_TTL_SECONDS)
         new_like_data = f"like:{sent.chat.id}:{sent.message_id}"
         new_dislike_data = f"dislike:{sent.chat.id}:{sent.message_id}"
         like_button = InlineKeyboardButton(text="👍 0", callback_data=new_like_data)
@@ -147,19 +147,19 @@ async def process_results(message: Message, results: list) -> None:
         logging.debug("Все ссылки уже были отправлены недавно.")
 
 
-def filter_recent_links(chat_id: int, results: list) -> list:
+async def filter_recent_links(chat_id: int, results: list) -> list:
     """
     Фильтрует ссылки, которые уже были отправлены недавно для конкретного чата.
     """
     filtered_results = []
     for name, url in results:
-        if cache.is_recent_link(chat_id, url):
+        if await cache.is_recent_link(chat_id, url):
             logging.debug(
                 f"Пропуск отправки ссылки '{url}' для чата {chat_id} (отправлялась недавно)."
             )
         else:
             filtered_results.append((name, url))
-            cache.set_recent_link(chat_id, url, flag.TIMEOUT_MINUTES * 60)
+            await cache.set_recent_link(chat_id, url, flag.TIMEOUT_MINUTES * 60)
     return filtered_results
 
 
@@ -179,10 +179,12 @@ async def handle_like_callback(callback_query: CallbackQuery) -> None:
     _, chat_id_str, message_id_str = data.split(":")
     chat_id = int(chat_id_str)
     message_id = int(message_id_str)
-    if not cache.get_reaction(chat_id, message_id):
+    if not await cache.get_reaction(chat_id, message_id):
         await callback_query.answer()
         return
-    likes, dislikes = cache.increment_reaction(chat_id, message_id, "like", REACTION_TTL_SECONDS)
+    likes, dislikes = await cache.increment_reaction(
+        chat_id, message_id, "like", REACTION_TTL_SECONDS
+    )
     msg = callback_query.message
     like_button = InlineKeyboardButton(text=f"👍 {likes}", callback_data=f"like:{chat_id}:{message_id}")
     dislike_button = InlineKeyboardButton(text=f"👎 {dislikes}", callback_data=f"dislike:{chat_id}:{message_id}")
@@ -199,14 +201,16 @@ async def handle_dislike_callback(callback_query: CallbackQuery) -> None:
     _, chat_id_str, message_id_str = data.split(":")
     chat_id = int(chat_id_str)
     message_id = int(message_id_str)
-    if not cache.get_reaction(chat_id, message_id):
+    if not await cache.get_reaction(chat_id, message_id):
         await callback_query.answer()
         return
-    likes, dislikes = cache.increment_reaction(chat_id, message_id, "dislike", REACTION_TTL_SECONDS)
+    likes, dislikes = await cache.increment_reaction(
+        chat_id, message_id, "dislike", REACTION_TTL_SECONDS
+    )
     msg = callback_query.message
     if dislikes > likes:
         await msg.delete()
-        cache.remove_reaction(chat_id, message_id)
+        await cache.remove_reaction(chat_id, message_id)
         await callback_query.answer("Сообщение удалено")
     else:
         like_button = InlineKeyboardButton(text=f"👍 {likes}", callback_data=f"like:{chat_id}:{message_id}")

--- a/bot/storage/cache.py
+++ b/bot/storage/cache.py
@@ -1,130 +1,154 @@
-import os
-import sqlite3
-import threading
-from datetime import datetime
+"""Asynchronous in-memory cache with TTL support.
+
+This module replaces the previous SQLite-backed implementation with an
+``asyncio`` friendly in-memory cache.  It provides non-blocking operations
+and a background task that periodically removes expired entries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Dict, Tuple
 
 
-class SQLiteCache:
-    """Simple SQLite-backed cache with TTL support."""
+class AsyncTTLCache:
+    """Simple in-memory TTL cache.
 
-    def __init__(self, path: str = "data/cache.db"):
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        self.conn = sqlite3.connect(path, check_same_thread=False)
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS recent_links (
-                chat_id INTEGER NOT NULL,
-                url TEXT NOT NULL,
-                expires_at REAL NOT NULL,
-                PRIMARY KEY (chat_id, url)
-            )
-            """
-        )
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS reaction_counts (
-                chat_id INTEGER NOT NULL,
-                message_id INTEGER NOT NULL,
-                likes INTEGER NOT NULL DEFAULT 0,
-                dislikes INTEGER NOT NULL DEFAULT 0,
-                expires_at REAL NOT NULL,
-                PRIMARY KEY (chat_id, message_id)
-            )
-            """
-        )
-        self.conn.commit()
-        self.lock = threading.Lock()
+    The cache stores two kinds of data:
 
-    # --- Recent links operations ---
-    def set_recent_link(self, chat_id: int, url: str, ttl_seconds: int) -> None:
-        with self.lock:
-            expires_at = datetime.now().timestamp() + ttl_seconds
-            self.conn.execute(
-                "REPLACE INTO recent_links(chat_id, url, expires_at) VALUES(?,?,?)",
-                (chat_id, url, expires_at),
-            )
-            self.conn.commit()
+    * ``recent_links`` – remembers recently sent links for each chat to avoid
+      duplicates for a period of time.
+    * ``reaction_counts`` – counts likes/dislikes for a message and expires
+      after a configurable TTL.
 
-    def is_recent_link(self, chat_id: int, url: str) -> bool:
-        with self.lock:
-            now = datetime.now().timestamp()
-            cur = self.conn.execute(
-                "SELECT expires_at FROM recent_links WHERE chat_id=? AND url=?",
-                (chat_id, url),
-            )
-            row = cur.fetchone()
-            if not row:
+    Expired records are cleaned up periodically in the background so cache
+    operations do not spend time on housekeeping.
+    """
+
+    def __init__(self, cleanup_interval: float = 60.0) -> None:
+        self._recent_links: Dict[Tuple[int, str], float] = {}
+        self._reactions: Dict[Tuple[int, int], Dict[str, float]] = {}
+        self._lock = asyncio.Lock()
+        self._cleanup_interval = cleanup_interval
+        self._cleanup_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _ensure_cleanup(self) -> None:
+        """Start background cleanup task once an event loop is running."""
+
+        if self._cleanup_task is None:
+            loop = asyncio.get_running_loop()
+            self._cleanup_task = loop.create_task(self._cleanup_loop())
+
+    async def _cleanup_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._cleanup_interval)
+                await self._cleanup_expired()
+        except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+            pass
+
+    async def _cleanup_expired(self) -> None:
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        async with self._lock:
+            self._recent_links = {
+                key: exp for key, exp in self._recent_links.items() if exp > now
+            }
+            self._reactions = {
+                key: val
+                for key, val in self._reactions.items()
+                if val["expires_at"] > now
+            }
+
+    async def close(self) -> None:
+        """Cancel the background cleanup task."""
+
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._cleanup_task
+
+    # ------------------------------------------------------------------
+    # Recent links operations
+    async def set_recent_link(self, chat_id: int, url: str, ttl_seconds: int) -> None:
+        self._ensure_cleanup()
+        loop = asyncio.get_running_loop()
+        expires_at = loop.time() + ttl_seconds
+        async with self._lock:
+            self._recent_links[(chat_id, url)] = expires_at
+
+    async def is_recent_link(self, chat_id: int, url: str) -> bool:
+        self._ensure_cleanup()
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        async with self._lock:
+            expires_at = self._recent_links.get((chat_id, url))
+            if not expires_at:
                 return False
-            if row[0] < now:
-                self.conn.execute(
-                    "DELETE FROM recent_links WHERE chat_id=? AND url=?",
-                    (chat_id, url),
-                )
-                self.conn.commit()
+            if expires_at < now:
+                del self._recent_links[(chat_id, url)]
                 return False
             return True
 
-    # --- Reaction counts operations ---
-    def init_reaction(self, chat_id: int, message_id: int, ttl_seconds: int) -> None:
-        with self.lock:
-            expires_at = datetime.now().timestamp() + ttl_seconds
-            self.conn.execute(
-                "REPLACE INTO reaction_counts(chat_id, message_id, likes, dislikes, expires_at) VALUES(?,?,?,?,?)",
-                (chat_id, message_id, 0, 0, expires_at),
-            )
-            self.conn.commit()
+    # ------------------------------------------------------------------
+    # Reaction counts operations
+    async def init_reaction(self, chat_id: int, message_id: int, ttl_seconds: int) -> None:
+        self._ensure_cleanup()
+        loop = asyncio.get_running_loop()
+        expires_at = loop.time() + ttl_seconds
+        async with self._lock:
+            self._reactions[(chat_id, message_id)] = {
+                "likes": 0,
+                "dislikes": 0,
+                "expires_at": expires_at,
+            }
 
-    def increment_reaction(self, chat_id: int, message_id: int, reaction: str, ttl_seconds: int):
-        with self.lock:
-            now = datetime.now().timestamp()
-            expires_at = now + ttl_seconds
-            cur = self.conn.execute(
-                "SELECT likes, dislikes, expires_at FROM reaction_counts WHERE chat_id=? AND message_id=?",
-                (chat_id, message_id),
-            )
-            row = cur.fetchone()
-            if not row or row[2] < now:
+    async def increment_reaction(
+        self, chat_id: int, message_id: int, reaction: str, ttl_seconds: int
+    ) -> Tuple[int, int]:
+        self._ensure_cleanup()
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        expires_at = now + ttl_seconds
+        async with self._lock:
+            data = self._reactions.get((chat_id, message_id))
+            if not data or data["expires_at"] < now:
                 likes = dislikes = 0
             else:
-                likes, dislikes, _ = row
+                likes, dislikes = data["likes"], data["dislikes"]
             if reaction == "like":
                 likes += 1
             else:
                 dislikes += 1
-            self.conn.execute(
-                "REPLACE INTO reaction_counts(chat_id, message_id, likes, dislikes, expires_at) VALUES(?,?,?,?,?)",
-                (chat_id, message_id, likes, dislikes, expires_at),
-            )
-            self.conn.commit()
+            self._reactions[(chat_id, message_id)] = {
+                "likes": likes,
+                "dislikes": dislikes,
+                "expires_at": expires_at,
+            }
             return likes, dislikes
 
-    def get_reaction(self, chat_id: int, message_id: int):
-        with self.lock:
-            now = datetime.now().timestamp()
-            cur = self.conn.execute(
-                "SELECT likes, dislikes, expires_at FROM reaction_counts WHERE chat_id=? AND message_id=?",
-                (chat_id, message_id),
-            )
-            row = cur.fetchone()
-            if not row:
+    async def get_reaction(self, chat_id: int, message_id: int):
+        self._ensure_cleanup()
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        async with self._lock:
+            data = self._reactions.get((chat_id, message_id))
+            if not data:
                 return None
-            likes, dislikes, expires_at = row
-            if expires_at < now:
-                self.conn.execute(
-                    "DELETE FROM reaction_counts WHERE chat_id=? AND message_id=?",
-                    (chat_id, message_id),
-                )
-                self.conn.commit()
+            if data["expires_at"] < now:
+                del self._reactions[(chat_id, message_id)]
                 return None
-            return {"likes": likes, "dislikes": dislikes}
+            return {"likes": data["likes"], "dislikes": data["dislikes"]}
 
-    def remove_reaction(self, chat_id: int, message_id: int) -> None:
-        with self.lock:
-            self.conn.execute(
-                "DELETE FROM reaction_counts WHERE chat_id=? AND message_id=?",
-                (chat_id, message_id),
-            )
-            self.conn.commit()
+    async def remove_reaction(self, chat_id: int, message_id: int) -> None:
+        self._ensure_cleanup()
+        async with self._lock:
+            self._reactions.pop((chat_id, message_id), None)
 
 
-cache = SQLiteCache()
+# Default cache instance used throughout the project
+cache = AsyncTTLCache()
+

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,31 +1,37 @@
-import time
-from bot.storage.cache import SQLiteCache
+import asyncio
+
+import pytest
+
+from bot.storage.cache import AsyncTTLCache
 
 
-def test_recent_link_expiration(tmp_path):
-    cache = SQLiteCache(str(tmp_path / 'cache.db'))
-    cache.set_recent_link(123, 'http://example.com', ttl_seconds=1)
-    assert cache.is_recent_link(123, 'http://example.com') is True
-    time.sleep(1.1)
-    assert cache.is_recent_link(123, 'http://example.com') is False
-    cache.conn.close()
+@pytest.mark.asyncio
+async def test_recent_link_expiration():
+    cache = AsyncTTLCache(cleanup_interval=0.05)
+    await cache.set_recent_link(123, "http://example.com", ttl_seconds=0.05)
+    assert await cache.is_recent_link(123, "http://example.com") is True
+    await asyncio.sleep(0.1)
+    assert await cache.is_recent_link(123, "http://example.com") is False
+    await cache.close()
 
 
-def test_reaction_counts(tmp_path):
-    cache = SQLiteCache(str(tmp_path / 'cache.db'))
-    cache.init_reaction(1, 42, ttl_seconds=1)
-    assert cache.get_reaction(1, 42) == {'likes': 0, 'dislikes': 0}
+@pytest.mark.asyncio
+async def test_reaction_counts():
+    cache = AsyncTTLCache(cleanup_interval=0.05)
+    await cache.init_reaction(1, 42, ttl_seconds=1)
+    assert await cache.get_reaction(1, 42) == {"likes": 0, "dislikes": 0}
 
-    likes, dislikes = cache.increment_reaction(1, 42, 'like', ttl_seconds=1)
+    likes, dislikes = await cache.increment_reaction(1, 42, "like", ttl_seconds=1)
     assert (likes, dislikes) == (1, 0)
-    likes, dislikes = cache.increment_reaction(1, 42, 'dislike', ttl_seconds=1)
+    likes, dislikes = await cache.increment_reaction(1, 42, "dislike", ttl_seconds=1)
     assert (likes, dislikes) == (1, 1)
-    assert cache.get_reaction(1, 42) == {'likes': 1, 'dislikes': 1}
+    assert await cache.get_reaction(1, 42) == {"likes": 1, "dislikes": 1}
 
-    cache.remove_reaction(1, 42)
-    assert cache.get_reaction(1, 42) is None
+    await cache.remove_reaction(1, 42)
+    assert await cache.get_reaction(1, 42) is None
 
-    cache.init_reaction(1, 43, ttl_seconds=1)
-    time.sleep(1.1)
-    assert cache.get_reaction(1, 43) is None
-    cache.conn.close()
+    await cache.init_reaction(1, 43, ttl_seconds=0.05)
+    await asyncio.sleep(0.1)
+    assert await cache.get_reaction(1, 43) is None
+    await cache.close()
+


### PR DESCRIPTION
## Summary
- replace SQLite-based cache with async in-memory cache with TTL and background cleanup
- update message handlers to await cache operations
- convert cache tests to asyncio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75a599f1c8329955f1dc6278016f1