### PR TITLE
feat: add command registry and decorator

### DIFF
--- a/bot/commands/add_chat.py
+++ b/bot/commands/add_chat.py
@@ -1,25 +1,17 @@
 import logging
-from aiogram.filters import Command
 from aiogram.types import Message
+
 from bot.config.flags import ADD_CHAT_ENABLE
 from bot.utils.chat_manager import add_chat_async
+from bot.utils.command_registry import command
 
 
-async def can_add_chat(message: Message) -> bool:
-    if not ADD_CHAT_ENABLE:
-        logging.debug("Команда /add_chat временно отключена.")
-        return False
-    return True
-
-
+@command("add_chat", flag=ADD_CHAT_ENABLE)
 async def handle_add_chat(message: Message) -> None:
     try:
         await message.delete()
     except Exception as e:
-        logging.error(f"Не удалось удалить сообщение пользователя: {e}")
-
-    if not await can_add_chat(message):
-        return
+        logging.error("Не удалось удалить сообщение пользователя: %s", e)
 
     chat_id = message.chat.id
     chat_title = message.chat.title or "Личный чат"
@@ -28,9 +20,4 @@ async def handle_add_chat(message: Message) -> None:
     try:
         await add_chat_async(chat_id, chat_title, added_by)
     except Exception as e:
-        logging.error(f"Ошибка при добавлении чата: {e}")
-
-
-def register_add_chat_handler(dp) -> None:
-    dp.message.register(handle_add_chat,
-                        Command(commands=["add_chat"]))
+        logging.error("Ошибка при добавлении чата: %s", e)

--- a/bot/commands/announce.py
+++ b/bot/commands/announce.py
@@ -1,34 +1,32 @@
 import logging
-from typing import Optional, Tuple, Dict, Any
+from typing import Any, Dict, Optional, Tuple
 
 from aiogram import Router, types
-from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import StatesGroup, State
+from aiogram.fsm.state import State, StatesGroup
+from sqlalchemy import select
 
 from bot.config.flags import ANNOUNCE_ENABLE
 from bot.database import SessionLocal
 from bot.models import Chat
-from sqlalchemy import select
+from bot.utils.command_registry import command
 
 logger = logging.getLogger(__name__)
 router = Router()
 
 
-# Определяем FSM для команды announce
 class AnnounceState(StatesGroup):
+    """Состояния FSM для команды announce."""
     waiting_for_announce = State()
 
 
-async def prepare_announce(message: types.Message) -> (
-        Tuple)[Optional[str], Optional[types.Message]]:
+async def prepare_announce(message: types.Message) -> Tuple[Optional[str], Optional[types.Message]]:
     if message.reply_to_message:
         if message.text.startswith("/announce"):
             additional_text = message.text.replace("/announce", "", 1).strip()
         else:
             additional_text = message.text.strip()
-        return (additional_text if additional_text else None,
-                message.reply_to_message)
+        return additional_text if additional_text else None, message.reply_to_message
     else:
         if message.text.startswith("/announce"):
             parts = message.text.split(maxsplit=1)
@@ -38,23 +36,25 @@ async def prepare_announce(message: types.Message) -> (
         return additional_text if additional_text else None, None
 
 
-async def send_announce_to_chat(chat: Dict[str, Any],
-                                message: types.Message,
-                                announce_message: Optional[str],
-                                reply_to_message: Optional[types.Message])\
-        -> None:
-    """
-    Отправляет рассылку в один чат: если announce_message задан, отправляет его,
-    если reply_to_message задан, пересылает его.
-    """
+async def send_announce_to_chat(
+    chat: Dict[str, Any],
+    message: types.Message,
+    announce_message: Optional[str],
+    reply_to_message: Optional[types.Message],
+) -> None:
+    """Отправляет рассылку в один чат."""
     try:
         if announce_message:
             await message.bot.send_message(chat["id"], announce_message)
         if reply_to_message:
             await reply_to_message.forward(chat["id"])
     except Exception as e:
-        logger.warning(f"Не удалось отправить сообщение в чат "
-                       f"{chat['id']} ({chat['title']}): {e}")
+        logger.warning(
+            "Не удалось отправить сообщение в чат %s (%s): %s",
+            chat["id"],
+            chat["title"],
+            e,
+        )
 
 
 async def process_announce(
@@ -76,27 +76,25 @@ async def process_announce(
         await message.answer("Нет активных чатов для отправки.")
         return
 
-    chat_list = [{"id": chat.chat_id,
-                  "title": chat.title} for chat in chat_list_db]
+    chat_list = [{"id": chat.chat_id, "title": chat.title} for chat in chat_list_db]
     for chat in chat_list:
-        await send_announce_to_chat(chat,
-                                    message,
-                                    announce_message,
-                                    reply_to_message)
+        await send_announce_to_chat(
+            chat,
+            message,
+            announce_message,
+            reply_to_message,
+        )
 
     await message.answer("Сообщение отправлено во все активные чаты.")
 
 
-@router.message(Command("announce", prefix="/"))
+@command("announce", flag=ANNOUNCE_ENABLE, admin_only=True, router=router)
 async def handle_announce(message: types.Message, state: FSMContext) -> None:
-    if not ANNOUNCE_ENABLE:
-        await message.answer("Команда временно отключена.")
-        return
-
     announce_text, reply_msg = await prepare_announce(message)
     if announce_text is None and reply_msg is None:
-        await message.answer("Введите текст для рассылки "
-                             "в чаты или введите \"отмена\":")
+        await message.answer(
+            "Введите текст для рассылки в чаты или введите \"отмена\":"
+        )
         await state.set_state(AnnounceState.waiting_for_announce)
         await state.update_data(initial_reply_id=message.message_id)
         return
@@ -105,8 +103,7 @@ async def handle_announce(message: types.Message, state: FSMContext) -> None:
 
 
 @router.message(AnnounceState.waiting_for_announce)
-async def process_announce_input(message: types.Message,
-                                 state: FSMContext) -> None:
+async def process_announce_input(message: types.Message, state: FSMContext) -> None:
     if message.text.strip().lower() in ["отмена", "cancel"]:
         await message.answer("Рассылка отменена.")
         await state.clear()
@@ -119,10 +116,3 @@ async def process_announce_input(message: types.Message,
 
     await process_announce(message, announce_text, reply_msg)
     await state.clear()
-
-
-def register_announce_handler(dp) -> None:
-    dp.message.register(handle_announce,
-                        Command(commands=["announce"]))
-    dp.message.register(process_announce_input,
-                        AnnounceState.waiting_for_announce)

--- a/bot/commands/best_qa.py
+++ b/bot/commands/best_qa.py
@@ -1,34 +1,34 @@
-from aiogram.filters import Command
 from aiogram.types import Message
+
 from bot.config.flags import BEST_QA_ENABLE
+from bot.utils.command_registry import command
 from bot.utils.game_engine import (
     update_last_winner,
     update_winner_stats,
     get_random_participant,
     is_new_day,
     format_winner_mention,
-    get_last_winner
+    get_last_winner,
 )
 
 
+@command("best_qa", flag=BEST_QA_ENABLE)
 async def handle_best_qa(message: Message) -> None:
-    if not BEST_QA_ENABLE:
-        await message.answer("Команда временно отключена.")
-        return
     if message.chat.type == "private":
         await message.answer("Эта команда доступна только в групповых чатах.")
         return
 
     chat_id = str(message.chat.id)
-    # Если уже выбран победитель сегодня, уведомляем об этом
     if not await is_new_day(chat_id):
         last = await get_last_winner(chat_id)
         if last:
-            mention = format_winner_mention(last.winner_user_id,
-                                            last.winner_full_name)
-            await message.answer(f"Сегодня лучший тестировщик "
-                                 f"уже выбран: {mention} 🎉",
-                                 parse_mode="HTML")
+            mention = format_winner_mention(
+                last.winner_user_id, last.winner_full_name
+            )
+            await message.answer(
+                f"Сегодня лучший тестировщик уже выбран: {mention} 🎉",
+                parse_mode="HTML",
+            )
         return
 
     participant = await get_random_participant(chat_id)
@@ -41,19 +41,17 @@ async def handle_best_qa(message: Message) -> None:
         message.chat.title or "Личный чат",
         str(participant.user_id),
         participant.full_name,
-        participant.username
+        participant.username,
     )
     await update_winner_stats(
         chat_id,
         message.chat.title or "Личный чат",
         str(participant.user_id),
         participant.full_name,
-        participant.username
+        participant.username,
     )
     mention = format_winner_mention(participant.user_id, participant.full_name)
-    await message.answer(f"Сегодня лучший тестировщик {mention} 🎉",
-                         parse_mode="HTML")
-
-
-def register_best_qa_handler(dp) -> None:
-    dp.message.register(handle_best_qa, Command(commands=["best_qa"]))
+    await message.answer(
+        f"Сегодня лучший тестировщик {mention} 🎉",
+        parse_mode="HTML",
+    )

--- a/bot/commands/best_qa_stat.py
+++ b/bot/commands/best_qa_stat.py
@@ -1,18 +1,16 @@
 import logging
-from aiogram.filters import Command
 from aiogram.types import Message
+from sqlalchemy import select
+
 from bot.config.flags import BEST_QA_STAT_ENABLE
 from bot.database import SessionLocal
 from bot.models import WinnerStats
-from sqlalchemy import select
+from bot.utils.command_registry import command
 from bot.utils.game_engine import format_declension
 
 
 async def get_stats(chat_id: str) -> list:
-    """
-    Получает статистику победителей для заданного чата из базы данных,
-    сортируя записи по количеству побед (от большего к меньшему).
-    """
+    """Получает статистику победителей для заданного чата."""
     async with SessionLocal() as session:
         try:
             result = await session.execute(
@@ -27,24 +25,20 @@ async def get_stats(chat_id: str) -> list:
 
 
 def format_stats(message: Message, stats: list) -> str:
-    """
-    Форматирует статистику победителей в строку для отправки пользователю.
-    """
-    chat_title = stats[0].chat_title if stats[0].chat_title \
-        else message.chat.title
+    """Форматирует статистику победителей."""
+    chat_title = stats[0].chat_title if stats[0].chat_title else message.chat.title
     stat_lines = [f"Статистика победителей для чата: {chat_title}:"]
     for stat in stats:
         username = f" (@{stat.username})" if stat.username else ""
         declension = format_declension(stat.wins)
-        stat_lines.append(f"• {stat.full_name}{username}: "
-                          f"{stat.wins} {declension}")
+        stat_lines.append(
+            f"• {stat.full_name}{username}: {stat.wins} {declension}"
+        )
     return "\n".join(stat_lines)
 
 
+@command("best_qa_stat", flag=BEST_QA_STAT_ENABLE)
 async def handle_best_qa_stat(message: Message) -> None:
-    if not BEST_QA_STAT_ENABLE:
-        await message.answer("Команда временно отключена.")
-        return
     if message.chat.type == "private":
         await message.answer("Статистика доступна только для групповых чатов.")
         return
@@ -57,8 +51,3 @@ async def handle_best_qa_stat(message: Message) -> None:
 
     help_text = format_stats(message, stats)
     await message.answer(help_text)
-
-
-def register_best_qa_stat_handler(dp) -> None:
-    dp.message.register(handle_best_qa_stat,
-                        Command(commands=["best_qa_stat"]))

--- a/bot/commands/chat_list.py
+++ b/bot/commands/chat_list.py
@@ -1,38 +1,16 @@
 import logging
 from aiogram import Router, types
-from aiogram.filters import Command
-from sqlalchemy import select
 
+from bot.config.flags import GET_CHAT_LIST
 from bot.utils.chat_manager import get_all_chats_async
-from bot.database import SessionLocal
-from bot.models import AdminUser
+from bot.utils.command_registry import command
 
 logger = logging.getLogger(__name__)
 router = Router()
 
 
-@router.message(Command("chat_list", prefix="/"))
+@command("chat_list", flag=GET_CHAT_LIST, admin_only=True, router=router)
 async def handle_chat_list(message: types.Message) -> None:
-    # Проверяем, есть ли активная запись для пользователя в таблице admin_users
-    async with SessionLocal() as session:
-        try:
-            result = await session.execute(
-                select(AdminUser).filter(
-                    AdminUser.user_id == str(message.from_user.id),
-                    AdminUser.is_active.is_(True),
-                )
-            )
-            admin_record = result.scalars().first()
-        except Exception as e:
-            logger.error("Ошибка проверки прав администратора: %s", e)
-            admin_record = None
-
-    if not admin_record:
-        await message.answer("У вас нет прав для использования этой команды.\n"
-                             "Запросить права вы можете командой /get_access")
-        return
-
-    # Получаем список чатов
     chats = await get_all_chats_async()
     if not chats:
         await message.answer("Список чатов пуст.")
@@ -45,7 +23,3 @@ async def handle_chat_list(message: types.Message) -> None:
         response_lines.append(f"{title} (ID: {chat.get('chat_id')}) - {status}")
     response_text = "\n".join(response_lines)
     await message.answer(response_text)
-
-
-def register_chat_list_handler(dp) -> None:
-    dp.message.register(handle_chat_list, Command(commands=["chat_list"]))

--- a/bot/commands/docs.py
+++ b/bot/commands/docs.py
@@ -1,36 +1,30 @@
-from aiogram.filters import Command
-from aiogram.types import Message
-from bot.modules.menu import create_menu
-from bot.config.flags import DOCS_ENABLE
 import logging
 from aiogram.fsm.context import FSMContext
+from aiogram.types import Message
+
+from bot.config.flags import DOCS_ENABLE
+from bot.modules.menu import create_menu
+from bot.utils.command_registry import command
 
 logger = logging.getLogger(__name__)
 
 
+@command("docs", flag=DOCS_ENABLE)
 async def handle_docs(message: Message, state: FSMContext) -> None:
-    """
-    Обрабатывает команду /docs.
-    Сбрасывает активное FSM-состояние, проверяет идентификатор пользователя,
-    затем, если DOCS_ENABLE включена, формирует меню для данного пользователя.
-    Если меню пустое – информирует пользователя, иначе отправляет сообщение с меню.
-    """
-    # Сброс FSM-состояния
+    """Обрабатывает команду /docs."""
     await state.clear()
-
-    # Получаем user_id, если он определён
     user_id = message.from_user.id if message.from_user and message.from_user.id else None
     if user_id is None:
         logger.error("Ошибка: невозможно определить идентификатор пользователя.")
         await message.answer("Ошибка: не удалось определить ваш идентификатор.")
         return
 
-    logger.info(f"Команда /docs вызвана пользователем {user_id} (@{message.from_user.username}, {message.from_user.full_name})")
-
-    if not DOCS_ENABLE:
-        logger.warning("Команда /docs временно отключена.")
-        await message.answer("Команда временно отключена.")
-        return
+    logger.info(
+        "Команда /docs вызвана пользователем %s (@%s, %s)",
+        user_id,
+        message.from_user.username,
+        message.from_user.full_name,
+    )
 
     try:
         menu, _ = create_menu(user_id=user_id)
@@ -40,17 +34,12 @@ async def handle_docs(message: Message, state: FSMContext) -> None:
             return
 
         main_menu_text = "Вот какие ссылки я знаю.\nВыберите из меню ниже:"
-        # Сохраняем текст главного меню в состоянии, если требуется для дальнейшей работы
         await state.update_data(main_menu_text=main_menu_text)
         await message.answer(main_menu_text, reply_markup=menu)
     except Exception as e:
-        logger.error(f"Ошибка при обработке команды /docs для пользователя {user_id}: {e}")
+        logger.error(
+            "Ошибка при обработке команды /docs для пользователя %s: %s",
+            user_id,
+            e,
+        )
         await message.reply(f"Произошла ошибка: {e}")
-
-
-def register_docs_handler(dp) -> None:
-    """
-    Регистрирует обработчик команды /docs.
-    :param dp: Экземпляр Dispatcher.
-    """
-    dp.message.register(handle_docs, Command(commands=["docs"]))

--- a/bot/commands/epa_contacts.py
+++ b/bot/commands/epa_contacts.py
@@ -1,21 +1,14 @@
 from aiogram import Router, types
-from aiogram.filters import Command
+
 from bot.config.flags import GET_EPA_CONTACTS_ENABLE
+from bot.utils.command_registry import command
 
 router = Router()
 
 
-@router.message(Command("epa_contacts", prefix="/"))
+@command("epa_contacts", flag=GET_EPA_CONTACTS_ENABLE, router=router)
 async def handle_epa_contacts(message: types.Message) -> None:
-    if not GET_EPA_CONTACTS_ENABLE:
-        await message.answer("Команда временно отключена.")
-        return None
-
     text = (
         "Контакты ЕПА для связи: https://sfera.inno.local/knowledge/pages?id=1524162"
     )
     await message.answer(text)
-
-
-def register_epa_contacts_handler(dp) -> None:
-    dp.message.register(handle_epa_contacts, Command(commands=["epa_contacts"]))

--- a/bot/commands/epa_guide.py
+++ b/bot/commands/epa_guide.py
@@ -1,22 +1,15 @@
 from aiogram import Router, types
-from aiogram.filters import Command
+
 from bot.config.flags import GET_EPA_GUIDE_ENABLE
+from bot.utils.command_registry import command
 
 router = Router()
 
 
-@router.message(Command("epa_guide", prefix="/"))
+@command("epa_guide", flag=GET_EPA_GUIDE_ENABLE, router=router)
 async def handle_epa_guide(message: types.Message) -> None:
-    if not GET_EPA_GUIDE_ENABLE:
-        await message.answer("Команда временно отключена.")
-        return None
-
     text = (
         "Авторизация по старой цепочке (ЕПА-3): https://sfera.inno.local/knowledge/pages?id=1513112\n"
         "Авторизация по новой цепочке (ЕПА-10): https://sfera.inno.local/knowledge/pages?id=1513113"
     )
     await message.answer(text)
-
-
-def register_epa_guide_handler(dp) -> None:
-    dp.message.register(handle_epa_guide, Command(commands=["epa_guide"]))

--- a/bot/commands/get_access.py
+++ b/bot/commands/get_access.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from typing import Tuple
 
 from aiogram import Router, types
-from aiogram.filters import Command
-from bot.database import SessionLocal
-from bot.models import AdminUser
-from bot.config.flags import GET_ACCESS_ENABLE
-from bot.config.tokens import ADMIN_USER_ID
 from sqlalchemy import select
 
+from bot.config.flags import GET_ACCESS_ENABLE
+from bot.config.tokens import ADMIN_USER_ID
+from bot.database import SessionLocal
+from bot.models import AdminUser
+from bot.utils.command_registry import command
 
 logger = logging.getLogger(__name__)
 router = Router()
@@ -31,8 +31,7 @@ async def access_already_granted(message: types.Message):
             return False
 
 
-def prepare_admin_request(message: types.Message) \
-        -> Tuple[str, types.InlineKeyboardMarkup]:
+def prepare_admin_request(message: types.Message) -> Tuple[str, types.InlineKeyboardMarkup]:
     user_id = message.from_user.id
     full_name = message.from_user.full_name
     username = message.from_user.username or ""
@@ -44,43 +43,36 @@ def prepare_admin_request(message: types.Message) \
         f"Username: @{username}\n"
         f"Время запроса: {request_time}"
     )
-    keyboard = types.InlineKeyboardMarkup(inline_keyboard=[
-        [types.InlineKeyboardButton(text="Принять",
-                                    callback_data=f"access:accept:{user_id}")],
-        [types.InlineKeyboardButton(text="Отклонить",
-                                    callback_data=f"access:decline:{user_id}")]
-    ])
+    keyboard = types.InlineKeyboardMarkup(
+        inline_keyboard=[
+            [types.InlineKeyboardButton(text="Принять", callback_data=f"access:accept:{user_id}")],
+            [types.InlineKeyboardButton(text="Отклонить", callback_data=f"access:decline:{user_id}")],
+        ]
+    )
     return admin_text, keyboard
 
 
+@command("get_access", flag=GET_ACCESS_ENABLE, router=router)
 async def handle_get_access(message: types.Message) -> None:
     if message.chat.type != "private":
-        await message.answer("Эта команда доступна только в "
-                             "личных сообщениях с ботом.")
-        return
-
-    if not GET_ACCESS_ENABLE:
-        await message.answer("Команда временно отключена.")
+        await message.answer("Эта команда доступна только в личных сообщениях с ботом.")
         return
 
     if await access_already_granted(message):
         await message.answer("Доступ уже предоставлен")
         return
 
-    # Если доступа нет, отправляем запрос администратору
     await message.answer("Ожидайте предоставление доступа.")
-
     admin_text, keyboard = prepare_admin_request(message)
     try:
-        # Замените "YOUR_ADMIN_CHAT_ID" на нужный ID
-        # или используйте переменную из конфигурации
-        await message.bot.send_message(chat_id=ADMIN_USER_ID,
-                                       text=admin_text,
-                                       reply_markup=keyboard)
+        await message.bot.send_message(
+            chat_id=ADMIN_USER_ID, text=admin_text, reply_markup=keyboard
+        )
     except Exception as e:
         logger.error("Ошибка отправки запроса администратору: %s", e)
-        await message.answer("Произошла ошибка при отправке запроса "
-                             "администратору. Попробуйте позже.")
+        await message.answer(
+            "Произошла ошибка при отправке запроса администратору. Попробуйте позже."
+        )
 
 
 async def handle_accept_callback(
@@ -117,12 +109,10 @@ async def handle_accept_callback(
             await callback.answer("Произошла ошибка. Попробуйте позже.")
 
 
-async def handle_decline_callback(callback: types.CallbackQuery,
-                                  target_user_id: int) -> None:
+async def handle_decline_callback(callback: types.CallbackQuery, target_user_id: int) -> None:
     try:
         await callback.message.edit_reply_markup(reply_markup=None)
-        await callback.bot.send_message(chat_id=target_user_id,
-                                        text="Вам отказано в доступе")
+        await callback.bot.send_message(chat_id=target_user_id, text="Вам отказано в доступе")
         await callback.answer("Доступ отклонён.")
     except Exception as e:
         logger.error("Ошибка обработки decline callback: %s", e)
@@ -150,8 +140,6 @@ async def process_access_callback(callback: types.CallbackQuery) -> None:
         await callback.answer("Неизвестное действие.")
 
 
-def register_get_access_handler(dp) -> None:
-    dp.message.register(handle_get_access,
-                        Command(commands=["get_access"]))
-    dp.callback_query.register(process_access_callback,
-                               lambda cq: cq.data.startswith("access:"))
+router.callback_query.register(
+    process_access_callback, lambda cq: cq.data.startswith("access:")
+)

--- a/bot/commands/help.py
+++ b/bot/commands/help.py
@@ -1,70 +1,40 @@
 import logging
-from aiogram.filters import Command
 from aiogram.types import Message
+
+from bot.config.flags import HELP_ENABLE
 from bot.modules.commands_list import get_all_commands
-from bot.database import SessionLocal
-from bot.models import AdminUser
-from sqlalchemy import select
+from bot.utils.admins import is_user_admin_db
+from bot.utils.command_registry import command
 
 logger = logging.getLogger(__name__)
 
 
-async def is_user_admin_db(user_id: int) -> bool:
-    """
-    Проверяет, является ли пользователь администратором,
-    запрашивая наличие активной записи в таблице admin_users.
-    """
-    async with SessionLocal() as session:
-        try:
-            result = await session.execute(
-                select(AdminUser).filter(
-                    AdminUser.user_id == str(user_id),
-                    AdminUser.is_active.is_(True),
-                )
-            )
-            admin_record = result.scalars().first()
-            return admin_record is not None
-        except Exception as e:
-            logger.error("Ошибка проверки админа в БД: %s", e)
-            return False
-
-
+@command("help", flag=HELP_ENABLE)
 async def handle_help(message: Message):
-    # Определяем, является ли пользователь администратором,
-    # проверяя запись в БД.
+    """Обрабатывает команду /help."""
     user_is_admin = await is_user_admin_db(message.from_user.id)
-
-    # Получаем полный список команд с учетом прав пользователя.
     commands = get_all_commands(user_is_admin=user_is_admin)
-    logger.debug(f"Все команды: {commands}")
+    logger.debug("Все команды: %s", commands)
 
-    # Определяем тип чата.
-    chat_type = "private_chat" if message.chat.type == "private" \
-        else "group_chat"
-
-    # Фильтруем команды по типу чата и по видимости в справке.
+    chat_type = "private_chat" if message.chat.type == "private" else "group_chat"
     visible_commands = [
-        cmd["command"] for cmd in commands
+        cmd["command"]
+        for cmd in commands
         if cmd.get(chat_type) and cmd.get("visible_in_help", True)
     ]
-    logger.debug(f"Доступные команды для {chat_type} "
-                 f"(admin={user_is_admin}): {visible_commands}")
+    logger.debug(
+        "Доступные команды для %s (admin=%s): %s",
+        chat_type,
+        user_is_admin,
+        visible_commands,
+    )
 
     if not visible_commands:
         await message.answer("Нет доступных команд для вашего чата.")
         return
 
-    # Формируем текст справки.
     help_text = "Привет! Вот список доступных команд:\n\n"
     for command in visible_commands:
         help_text += f"/{command.command} — {command.description}\n"
 
     await message.answer(help_text)
-
-
-def register_help_handler(dp):
-    """
-    Регистрирует обработчик команды /help.
-    :param dp: Экземпляр Dispatcher
-    """
-    dp.message.register(handle_help, Command(commands=["help"]))

--- a/bot/commands/remove_chat.py
+++ b/bot/commands/remove_chat.py
@@ -1,34 +1,23 @@
 import logging
-from aiogram.filters import Command
 from aiogram.types import Message
+
 from bot.config.flags import REMOVE_CHAT_ENABLE
 from bot.utils.chat_manager import remove_chat_async
+from bot.utils.command_registry import command
 
 
+@command("remove_chat", flag=REMOVE_CHAT_ENABLE)
 async def handle_remove_chat(message: Message) -> None:
-    """
-    Обработчик команды /remove_chat.
-    Если команда включена и вызывающий является администратором,
-    чат помечается как удалённый в базе данных.
-    После чего сообщение пользователя удаляется.
-    """
+    """Обработчик команды /remove_chat."""
     try:
         await message.delete()
     except Exception as e:
-        logging.error(f"Не удалось удалить сообщение пользователя: {e}")
-
-    if not REMOVE_CHAT_ENABLE:
-        logging.debug("Команда /remove_chat временно отключена.")
-        return
+        logging.error("Не удалось удалить сообщение пользователя: %s", e)
 
     chat_id = message.chat.id
     removed_by = message.from_user.username or message.from_user.full_name
 
     if await remove_chat_async(chat_id, removed_by):
-        logging.info(f"Чат {chat_id} успешно помечен как удалённый.")
+        logging.info("Чат %s успешно помечен как удалённый.", chat_id)
     else:
-        logging.debug(f"Чат {chat_id} не найден или уже удалён.")
-
-
-def register_remove_chat_handler(dp) -> None:
-    dp.message.register(handle_remove_chat, Command(commands=["remove_chat"]))
+        logging.debug("Чат %s не найден или уже удалён.", chat_id)

--- a/bot/commands/search.py
+++ b/bot/commands/search.py
@@ -1,77 +1,67 @@
 import asyncio
 import logging
-import openai
 from typing import Optional
 
+import openai
 from aiogram import Router, types
-from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
-from aiogram.fsm.state import StatesGroup, State
+from aiogram.fsm.state import State, StatesGroup
 
-from bot.config.tokens import OPENAI_API_KEY
+from bot.config.flags import SEARCH_ENABLE
 from bot.config.gpt_prompt import PROMPT
+from bot.config.tokens import OPENAI_API_KEY
 from bot.database import SessionLocal
+from bot.utils.command_registry import command
 
 openai.api_key = OPENAI_API_KEY
 router = Router()
 
 
-# Определяем состояния для диалога поиска
 class SearchState(StatesGroup):
+    """Состояния для диалога поиска."""
     waiting_for_query = State()
 
 
-@router.message(Command("search", prefix="/"))
+@command("search", flag=SEARCH_ENABLE, router=router)
 async def cmd_search(message: types.Message, state: FSMContext) -> None:
-    """
-    Обрабатывает команду /search.
-    Если команда вызвана с дополнительным текстом
-    или в реплае – обрабатывается немедленно.
-    Иначе переводит пользователя в режим ожидания ввода,
-    сохраняя ID вызывающего.
-    """
+    """Обрабатывает команду /search."""
     parts = message.text.split(maxsplit=1)
     additional_text: str = parts[1].strip() if len(parts) > 1 else ""
     reply_text: str = ""
     if message.reply_to_message and message.reply_to_message.text:
         reply_text = message.reply_to_message.text.strip()
 
-    # Формирование итогового запроса на основе реплая и дополнительного текста
     if reply_text:
-        user_query: str = reply_text + (f" {additional_text}"
-                                        if additional_text else "")
-        logging.info("Команда /search вызвана в реплае "
-                     "пользователем %s, итоговый запрос: %s",
-                     message.from_user.id, user_query)
+        user_query: str = reply_text + (f" {additional_text}" if additional_text else "")
+        logging.info(
+            "Команда /search вызвана в реплае пользователем %s, итоговый запрос: %s",
+            message.from_user.id,
+            user_query,
+        )
         await process_immediate_query(user_query, message, state)
         return
     elif additional_text:
         user_query = additional_text
-        logging.info("Команда /search вызвана с запросом "
-                     "от пользователя %s: %s",
-                     message.from_user.id, user_query)
+        logging.info(
+            "Команда /search вызвана с запросом от пользователя %s: %s",
+            message.from_user.id,
+            user_query,
+        )
         await process_immediate_query(user_query, message, state)
         return
     else:
-        # Если дополнительных данных нет – переводим в режим ожидания ввода
-        logging.info("Команда /search вызвана без запроса, "
-                     "ожидается ввод пользователя %s",
-                     message.from_user.id)
-        await message.answer("Введите текст запроса для "
-                             "поиска (или напишите «отмена»):")
+        logging.info(
+            "Команда /search вызвана без запроса, ожидается ввод пользователя %s",
+            message.from_user.id,
+        )
+        await message.answer("Введите текст запроса для поиска (или напишите «отмена»):")
         await state.update_data(user_id=message.from_user.id)
         await state.set_state(SearchState.waiting_for_query)
         asyncio.create_task(search_timeout(message, state))
 
 
-async def process_immediate_query(user_query: str,
-                                  message: types.Message,
-                                  state: FSMContext) -> None:
-    """
-    Обрабатывает запрос, который можно выполнить сразу.
-    Записывает запрос в базу, отправляет сообщение "Обрабатываю ваш запрос...",
-    вызывает ChatGPT и отправляет результат в чат.
-    """
+async def process_immediate_query(user_query: str, message: types.Message, state: FSMContext) -> None:
+    """Обрабатывает запрос, который можно выполнить сразу."""
     await log_search_request_db(message, user_query)
     await message.answer("Обрабатываю ваш запрос...")
     answer: str = await query_openai(user_query, message)
@@ -80,48 +70,41 @@ async def process_immediate_query(user_query: str,
 
 
 async def search_timeout(message: types.Message, state: FSMContext) -> None:
-    """
-    Если в течение 120 секунд не поступил запрос – отменяет режим ожидания.
-    """
+    """Отменяет режим ожидания, если не поступил запрос."""
     await asyncio.sleep(120)
     current_state: Optional[str] = await state.get_state()
     if current_state == SearchState.waiting_for_query.state:
-        logging.info("Таймаут: пользователь %s не ввёл запрос за 120 секунд",
-                     message.from_user.id)
-        await message.answer("Код ошибки R0604.\n"
-                             "Время ожидания истекло, операция отменена.")
+        logging.info(
+            "Таймаут: пользователь %s не ввёл запрос за 120 секунд",
+            message.from_user.id,
+        )
+        await message.answer(
+            "Код ошибки R0604.\nВремя ожидания истекло, операция отменена."
+        )
         await state.clear()
 
 
-@router.message(lambda m: m.text and m.text.strip().startswith("/"),
-                SearchState.waiting_for_query)
+@router.message(lambda m: m.text and m.text.strip().startswith("/"), SearchState.waiting_for_query)
 async def cancel_on_command(message: types.Message, state: FSMContext) -> None:
-    """
-    Если в режиме ожидания пользователь вызывает
-    другую команду – отменяет ожидание.
-    """
-    logging.info("Пользователь %s вызвал другую команду, "
-                 "завершаем ожидание поиска",
-                 message.from_user.id)
+    """Если во время ожидания пользователь вызывает другую команду."""
+    logging.info(
+        "Пользователь %s вызвал другую команду, завершаем ожидание поиска",
+        message.from_user.id,
+    )
     await state.clear()
 
 
 @router.message(SearchState.waiting_for_query)
-async def process_search_query(message: types.Message,
-                               state: FSMContext) -> None:
-    """
-    Обрабатывает ввод в режиме ожидания.
-    Проверяет, что сообщение пришло от того же
-    пользователя, который вызвал команду.
-    При вводе "отмена" или "cancel" – отменяет операцию.
-    Иначе обрабатывает запрос.
-    """
+async def process_search_query(message: types.Message, state: FSMContext) -> None:
+    """Обрабатывает ввод в режиме ожидания."""
     data = await state.get_data()
     invoking_user: Optional[int] = data.get("user_id")
     if message.from_user.id != invoking_user:
-        logging.debug("Игнорирую сообщение от пользователя %s, "
-                      "ожидался ввод от %s",
-                      message.from_user.id, invoking_user)
+        logging.debug(
+            "Игнорирую сообщение от пользователя %s, ожидался ввод от %s",
+            message.from_user.id,
+            invoking_user,
+        )
         return
 
     if message.text.strip().lower() in ["отмена", "cancel"]:
@@ -131,14 +114,18 @@ async def process_search_query(message: types.Message,
         return
 
     user_query = message.text.strip()
-    logging.info("Пользователь %s ввёл запрос: %s",
-                 message.from_user.id, user_query)
+    logging.info(
+        "Пользователь %s ввёл запрос: %s",
+        message.from_user.id,
+        user_query,
+    )
     await process_immediate_query(user_query, message, state)
 
 
 async def log_search_request_db(message: types.Message, user_query: str) -> None:
     """Логирует запрос пользователя в базу данных (таблица search_logs)."""
     from bot.models import SearchLog
+
     async with SessionLocal() as session:
         try:
             log_entry = SearchLog(
@@ -146,24 +133,22 @@ async def log_search_request_db(message: types.Message, user_query: str) -> None
                 username=message.from_user.username or "",
                 full_name=message.from_user.full_name,
                 query=user_query,
-                timestamp=message.date,  # или можно использовать datetime.utcnow()
+                timestamp=message.date,
             )
             session.add(log_entry)
             await session.commit()
         except Exception as e:
             await session.rollback()
-            logging.error(
-                "Ошибка при записи лога запроса в базу данных: %s", e
-            )
+            logging.error("Ошибка при записи лога запроса в базу данных: %s", e)
 
 
 async def query_openai(user_query: str, message: types.Message) -> str:
-    """
-    Отправляет запрос в OpenAI и возвращает ответ.
-    """
+    """Отправляет запрос в OpenAI и возвращает ответ."""
     try:
-        logging.info("Отправка запроса в OpenAI для пользователя %s",
-                     message.from_user.id)
+        logging.info(
+            "Отправка запроса в OpenAI для пользователя %s",
+            message.from_user.id,
+        )
         loop = asyncio.get_running_loop()
         response = await loop.run_in_executor(
             None,
@@ -171,21 +156,23 @@ async def query_openai(user_query: str, message: types.Message) -> str:
                 model="gpt-3.5-turbo",
                 messages=[
                     {"role": "system", "content": PROMPT},
-                    {"role": "user", "content": user_query}
+                    {"role": "user", "content": user_query},
                 ],
                 max_tokens=500,
-                temperature=0.7
-            )
+                temperature=0.7,
+            ),
         )
         answer: str = response.choices[0].message.content.strip()
-        logging.info("Получен ответ от OpenAI для пользователя %s: %s",
-                     message.from_user.id, answer)
+        logging.info(
+            "Получен ответ от OpenAI для пользователя %s: %s",
+            message.from_user.id,
+            answer,
+        )
         return answer
     except Exception as e:
-        logging.error("Ошибка вызова OpenAI API для пользователя %s: %s",
-                      message.from_user.id, e)
+        logging.error(
+            "Ошибка вызова OpenAI API для пользователя %s: %s",
+            message.from_user.id,
+            e,
+        )
         return "Произошла ошибка при обработке запроса. Попробуйте позже."
-
-
-def register_search_handler(dp) -> None:
-    dp.include_router(router)

--- a/bot/commands/start.py
+++ b/bot/commands/start.py
@@ -1,22 +1,13 @@
-from aiogram.filters import Command
 from aiogram.types import Message
 
+from bot.utils.command_registry import command
 
+
+@command("start")
 async def handle_start(message: Message):
-    """
-    Обрабатывает команду /start.
-    :param message: Сообщение от пользователя
-    """
+    """Обрабатывает команду /start."""
     await message.answer(
         "Привет! Я бот, который поможет найти ссылки на полезную документацию "
         "или разобраться в процессах тестирования МБ СМБ.\n"
         "Введите /help что бы узнать что я умею"
     )
-
-
-def register_start_handler(dp):
-    """
-    Регистрирует обработчики команды /start и кнопки "Список команд".
-    :param dp: Экземпляр Dispatcher
-    """
-    dp.message.register(handle_start, Command(commands=["start"]))

--- a/bot/commands/vtb_support.py
+++ b/bot/commands/vtb_support.py
@@ -1,21 +1,12 @@
 from aiogram import Router, types
-from aiogram.filters import Command
+
 from bot.config.flags import VTB_SUPPORT_ENABLE
+from bot.utils.command_registry import command
 
 router = Router()
 
 
-@router.message(Command("vtb_support", prefix="/"))
+@command("vtb_support", flag=VTB_SUPPORT_ENABLE, router=router)
 async def handle_vtb_support(message: types.Message) -> None:
-    if not VTB_SUPPORT_ENABLE:
-        await message.answer("Команда временно отключена.")
-        return None
-
-    text = (
-        "Телефон поддержки ВТБ - +74959818081"
-    )
+    text = "Телефон поддержки ВТБ - +74959818081"
     await message.answer(text)
-
-
-def register_vtb_support_handler(dp) -> None:
-    dp.message.register(handle_vtb_support, Command(commands=["vtb_support"]))

--- a/bot/utils/admins.py
+++ b/bot/utils/admins.py
@@ -1,0 +1,23 @@
+import logging
+from sqlalchemy import select
+
+from bot.database import SessionLocal
+from bot.models import AdminUser
+
+logger = logging.getLogger(__name__)
+
+
+async def is_user_admin_db(user_id: int) -> bool:
+    """Проверяет, имеет ли пользователь права администратора."""
+    async with SessionLocal() as session:
+        try:
+            result = await session.execute(
+                select(AdminUser).filter(
+                    AdminUser.user_id == str(user_id),
+                    AdminUser.is_active.is_(True),
+                )
+            )
+            return result.scalars().first() is not None
+        except Exception as e:
+            logger.error("Ошибка проверки прав администратора: %s", e)
+            return False

--- a/bot/utils/command_registry.py
+++ b/bot/utils/command_registry.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from .admins import is_user_admin_db
+
+COMMAND_REGISTRY: List[Dict[str, Any]] = []
+
+
+def command(
+    name: str,
+    flag: bool = True,
+    *,
+    admin_only: bool = False,
+    router: Optional[Router] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Декоратор для регистрации команд.
+
+    Args:
+        name: Имя команды без слеша.
+        flag: Флаг доступности команды.
+        admin_only: Требуются ли права администратора.
+        router: Опциональный Router для регистрации обработчика.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        async def wrapper(message: Message, *args, **kwargs):
+            if not flag:
+                logging.debug("Команда /%s временно отключена.", name)
+                return
+            if admin_only and not await is_user_admin_db(message.from_user.id):
+                await message.answer(
+                    "У вас нет прав для использования этой команды.\n"
+                    "Запросить права вы можете командой /get_access"
+                )
+                return
+            return await func(message, *args, **kwargs)
+
+        if router:
+            router.message.register(wrapper, Command(commands=[name]))
+        COMMAND_REGISTRY.append(
+            {
+                "name": name,
+                "handler": wrapper,
+                "router": router,
+            }
+        )
+        return wrapper
+
+    return decorator

--- a/bot/utils/handlers.py
+++ b/bot/utils/handlers.py
@@ -1,38 +1,24 @@
-from bot.commands.start import register_start_handler
-from bot.commands.help import register_help_handler
-from bot.commands.docs import register_docs_handler
-from bot.commands.announce import register_announce_handler
-from bot.commands.add_chat import register_add_chat_handler
-from bot.commands.remove_chat import register_remove_chat_handler
-from bot.commands.get_access import register_get_access_handler
-from bot.commands.search import register_search_handler
-from bot.commands.best_qa import register_best_qa_handler
-from bot.commands.best_qa_stat import register_best_qa_stat_handler
-from bot.commands.chat_list import register_chat_list_handler
-from bot.commands.epa_guide import register_epa_guide_handler
-from bot.commands.epa_contacts import register_epa_contacts_handler
-from bot.commands.vtb_support import register_vtb_support_handler
+import importlib
+import pkgutil
+
+from aiogram.filters import Command
+
+import bot.commands
 from bot.modules.buttons import register_button_handlers
 from bot.messages.messages import register_message_handlers
+from bot.utils.command_registry import COMMAND_REGISTRY
 
 
 def register_handlers(dp):
-    """
-    Регистрирует все обработчики бота.
-    """
-    register_start_handler(dp)
-    register_help_handler(dp)
-    register_docs_handler(dp)
-    register_search_handler(dp)
-    register_announce_handler(dp)
-    register_add_chat_handler(dp)
-    register_remove_chat_handler(dp)
-    register_get_access_handler(dp)
-    register_best_qa_handler(dp)
-    register_best_qa_stat_handler(dp)
-    register_chat_list_handler(dp)
-    register_epa_guide_handler(dp)
-    register_epa_contacts_handler(dp)
-    register_vtb_support_handler(dp)
+    """Регистрирует все обработчики бота."""
+    for module in pkgutil.iter_modules(bot.commands.__path__):
+        importlib.import_module(f"bot.commands.{module.name}")
+
+    for entry in COMMAND_REGISTRY:
+        router = entry.get("router")
+        if router:
+            dp.include_router(router)
+        else:
+            dp.message.register(entry["handler"], Command(commands=[entry["name"]]))
     register_button_handlers(dp)
     register_message_handlers(dp)


### PR DESCRIPTION
## Summary
- add decorator-based command registry with admin and flag support
- auto-import command modules and register via registry
- migrate commands to new registration pattern

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77e92bd5c83298d1bdd4fe4acb10f