### PR TITLE
Use async session for search logging

### DIFF
--- a/bot/commands/search.py
+++ b/bot/commands/search.py
@@ -6,6 +6,7 @@ import openai
 from aiogram import Router, types
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
+from sqlalchemy import insert
 
 from bot.config.flags import SEARCH_ENABLE
 from bot.config.gpt_prompt import PROMPT
@@ -62,6 +63,7 @@ async def cmd_search(message: types.Message, state: FSMContext) -> None:
 
 async def process_immediate_query(user_query: str, message: types.Message, state: FSMContext) -> None:
     """Обрабатывает запрос, который можно выполнить сразу."""
+    # Сохраняем запрос в базе данных
     await log_search_request_db(message, user_query)
     await message.answer("Обрабатываю ваш запрос...")
     answer: str = await query_openai(user_query, message)
@@ -128,14 +130,14 @@ async def log_search_request_db(message: types.Message, user_query: str) -> None
 
     async with SessionLocal() as session:
         try:
-            log_entry = SearchLog(
+            stmt = insert(SearchLog).values(
                 user_id=str(message.from_user.id),
                 username=message.from_user.username or "",
                 full_name=message.from_user.full_name,
                 query=user_query,
                 timestamp=message.date,
             )
-            session.add(log_entry)
+            await session.execute(stmt)
             await session.commit()
         except Exception as e:
             await session.rollback()

--- a/tests/test_commands_async.py
+++ b/tests/test_commands_async.py
@@ -1,8 +1,27 @@
 import pytest
+import pytest_asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from datetime import datetime
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from bot.commands import search, best_qa
+from bot.database import Base
+from bot.models import SearchLog
+
+
+@pytest_asyncio.fixture
+async def search_session_local(monkeypatch):
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    monkeypatch.setattr(search, "SessionLocal", TestingSessionLocal)
+    yield TestingSessionLocal
+    await engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -33,6 +52,23 @@ async def test_process_immediate_query(monkeypatch):
     )
     assert message.answer.await_args_list[1].args[0] == "result"
     state.clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_log_search_request_db(search_session_local):
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=1, username="user", full_name="User"),
+        date=datetime.now(),
+    )
+
+    await search.log_search_request_db(message, "hello")
+
+    async with search_session_local() as session:
+        result = await session.execute(select(SearchLog))
+        log = result.scalars().first()
+        assert log is not None
+        assert log.user_id == "1"
+        assert log.query == "hello"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- log search queries using AsyncSession `execute` and `commit`
- call async DB logging when processing immediate queries
- test search logging with in-memory async DB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a781079d9c83299a5abfbbfd59186c