### PR TITLE
Add tests for admin check and command decorator

### DIFF
--- a/tests/test_admins.py
+++ b/tests/test_admins.py
@@ -1,0 +1,36 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from bot.database import Base
+from bot.models import AdminUser
+from bot.utils import admins
+
+
+@pytest_asyncio.fixture
+async def admin_session(monkeypatch):
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    monkeypatch.setattr(admins, "SessionLocal", TestingSessionLocal)
+    yield TestingSessionLocal
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_is_user_admin_db(admin_session):
+    async with admin_session() as session:
+        session.add(
+            AdminUser(user_id="1", full_name="Admin", username="admin", is_active=True)
+        )
+        session.add(
+            AdminUser(user_id="3", full_name="Inactive", username="inactive", is_active=False)
+        )
+        await session.commit()
+
+    assert await admins.is_user_admin_db(1) is True
+    assert await admins.is_user_admin_db(2) is False
+    assert await admins.is_user_admin_db(3) is False

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,61 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from bot.utils import command_registry
+
+
+@pytest.mark.asyncio
+async def test_command_registered_and_exec():
+    command_registry.COMMAND_REGISTRY.clear()
+    called = {"value": False}
+
+    async def handler(message):
+        called["value"] = True
+        await message.answer("ok")
+
+    message = SimpleNamespace(from_user=SimpleNamespace(id=1), answer=AsyncMock())
+    decorated = command_registry.command("test")(handler)
+
+    assert command_registry.COMMAND_REGISTRY[-1]["name"] == "test"
+    await decorated(message)
+    assert called["value"] is True
+    message.answer.assert_awaited_once_with("ok")
+
+
+@pytest.mark.asyncio
+async def test_command_flag_false():
+    command_registry.COMMAND_REGISTRY.clear()
+    called = {"value": False}
+
+    async def handler(message):
+        called["value"] = True
+
+    message = SimpleNamespace(from_user=SimpleNamespace(id=1), answer=AsyncMock())
+    decorated = command_registry.command("test", flag=False)(handler)
+
+    await decorated(message)
+    assert called["value"] is False
+    message.answer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_command_admin_only(monkeypatch):
+    command_registry.COMMAND_REGISTRY.clear()
+    called = {"value": False}
+
+    async def handler(message):
+        called["value"] = True
+
+    message = SimpleNamespace(from_user=SimpleNamespace(id=1), answer=AsyncMock())
+    monkeypatch.setattr(
+        command_registry, "is_user_admin_db", AsyncMock(return_value=False)
+    )
+    decorated = command_registry.command("test", admin_only=True)(handler)
+
+    await decorated(message)
+    assert called["value"] is False
+    message.answer.assert_awaited_once_with(
+        "У вас нет прав для использования этой команды.\n"
+        "Запросить права вы можете командой /get_access"
+    )


### PR DESCRIPTION
## Summary
- Add tests for is_user_admin_db covering active, inactive, and missing users
- Test command decorator registration, disabled flag handling, and admin-only restrictions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a850dd38d48329ad5416c681c545a7