### PR TITLE
Add tests for game engine formatting

### DIFF
--- a/tests/test_game_engine_format.py
+++ b/tests/test_game_engine_format.py
@@ -1,0 +1,23 @@
+import pytest
+
+from bot.utils.game_engine import format_declension, format_winner_mention
+
+
+@pytest.mark.parametrize(
+    "wins,expected",
+    [
+        (1, "победа"),
+        (2, "победы"),
+        (5, "побед"),
+        (11, "побед"),
+    ],
+)
+def test_format_declension(wins, expected):
+    assert format_declension(wins) == expected
+
+
+def test_format_winner_mention():
+    assert (
+        format_winner_mention("1", "User")
+        == '<a href="tg://user?id=1">User</a>'
+    )


### PR DESCRIPTION
## Summary
- test format_declension for 1, 2, 5, and 11 wins
- test format_winner_mention creates proper Telegram link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86ad4f6108329a7f3ce01ba84716f