### PR TITLE
Ignore dispatcher argument in command decorator

### DIFF
--- a/bot/utils/command_registry.py
+++ b/bot/utils/command_registry.py
@@ -37,6 +37,11 @@ def command(
                     "Запросить права вы можете командой /get_access"
                 )
                 return
+            # aiogram v3 передает объект dispatcher среди аргументов обработчика,
+            # но большинство наших команд его не ожидают. Чтобы избежать ошибки
+            # вида "unexpected keyword argument 'dispatcher'", удаляем его из
+            # kwargs перед вызовом пользовательской функции.
+            kwargs.pop("dispatcher", None)
             return await func(message, *args, **kwargs)
 
         if router:

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -92,3 +92,22 @@ def test_command_router_registration():
     command_registry.COMMAND_REGISTRY[:] = command_registry.COMMAND_REGISTRY[
         :start_len
     ]
+
+
+@pytest.mark.asyncio
+async def test_command_ignores_dispatcher_kwarg():
+    command_registry.COMMAND_REGISTRY.clear()
+    called = {"value": False}
+
+    async def handler(message):
+        called["value"] = True
+
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=1), answer=AsyncMock()
+    )
+    decorated = command_registry.command("test")(handler)
+
+    # Обработчик должен отработать даже при передаче дополнительного
+    # параметра dispatcher, который игнорируется декоратором.
+    await decorated(message, dispatcher=object())
+    assert called["value"] is True


### PR DESCRIPTION
## Summary
- avoid passing unexpected `dispatcher` keyword argument to command handlers
- cover command decorator with test for ignored dispatcher kwarg

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a86cd922208329b9d89ea342b12cff