### PR TITLE
Filter unexpected kwargs in command decorator

### DIFF
--- a/bot/utils/command_registry.py
+++ b/bot/utils/command_registry.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -37,6 +38,17 @@ def command(
                     "Запросить права вы можете командой /get_access"
                 )
                 return
+            # aiogram v3 может передавать служебные параметры в kwargs,
+            # которые не предусмотрены нашим обработчиком. Чтобы избежать
+            # ошибок вида "unexpected keyword argument", фильтруем лишние
+            # ключи на основе сигнатуры функции.
+            if kwargs:
+                sig = inspect.signature(func)
+                if not any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    for p in sig.parameters.values()
+                ):
+                    kwargs = {k: v for k, v in kwargs.items() if k in sig.parameters}
             return await func(message, *args, **kwargs)
 
         if router:

--- a/bot/utils/command_registry.py
+++ b/bot/utils/command_registry.py
@@ -39,10 +39,12 @@ def command(
                 )
                 return
             # aiogram v3 может передавать служебные параметры в kwargs,
-            # которые не предусмотрены нашим обработчиком. Чтобы избежать
-            # ошибок вида "unexpected keyword argument", фильтруем лишние
-            # ключи на основе сигнатуры функции.
+            # такие как ``dispatcher`` или другие технические ключи.
+            # Чтобы предотвратить ошибки "unexpected keyword argument",
+            # сначала удаляем ``dispatcher``, затем фильтруем оставшиеся
+            # параметры на основе сигнатуры пользовательской функции.
             if kwargs:
+                kwargs.pop("dispatcher", None)
                 sig = inspect.signature(func)
                 if not any(
                     p.kind == inspect.Parameter.VAR_KEYWORD

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -111,3 +111,21 @@ async def test_command_ignores_extra_kwargs():
     # параметров, которые игнорируются декоратором.
     await decorated(message, dispatcher=object(), bots=object())
     assert called["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_command_removes_dispatcher_even_if_handler_accepts_kwargs():
+    command_registry.COMMAND_REGISTRY.clear()
+    received = {}
+
+    async def handler(message, **kw):
+        received.update(kw)
+
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=1), answer=AsyncMock()
+    )
+    decorated = command_registry.command("test")(handler)
+
+    await decorated(message, dispatcher="disp", bots="bot")
+    assert "dispatcher" not in received
+    assert received.get("bots") == "bot"

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -92,3 +92,22 @@ def test_command_router_registration():
     command_registry.COMMAND_REGISTRY[:] = command_registry.COMMAND_REGISTRY[
         :start_len
     ]
+
+
+@pytest.mark.asyncio
+async def test_command_ignores_extra_kwargs():
+    command_registry.COMMAND_REGISTRY.clear()
+    called = {"value": False}
+
+    async def handler(message):
+        called["value"] = True
+
+    message = SimpleNamespace(
+        from_user=SimpleNamespace(id=1), answer=AsyncMock()
+    )
+    decorated = command_registry.command("test")(handler)
+
+    # Обработчик должен отработать даже при передаче дополнительных
+    # параметров, которые игнорируются декоратором.
+    await decorated(message, dispatcher=object(), bots=object())
+    assert called["value"] is True


### PR DESCRIPTION
## Summary
- filter unknown keyword arguments in command decorator using function signatures
- extend tests to ensure extra kwargs like `dispatcher` and `bots` are ignored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86cd922208329b9d89ea342b12cff